### PR TITLE
Machine starts again with spaces in the name

### DIFF
--- a/src/main/java/me/pesekjak/machine/utils/FileUtils.java
+++ b/src/main/java/me/pesekjak/machine/utils/FileUtils.java
@@ -13,7 +13,8 @@ public final class FileUtils {
             .getProtectionDomain()
             .getCodeSource()
             .getLocation()
-            .getFile());
+            .getFile()
+            .replaceAll("%20", " "));
 
 
     private FileUtils() {


### PR DESCRIPTION
Fixed that Machine would throw an exception due to the spaces being replaced by %20 (HTML standard)