### PR TITLE
Code Generators Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Machine
+*/libs/versions.json
+
 # IntelliJ
 /out/
 .idea/

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -17,13 +17,6 @@ repositories {
 
 dependencies {
 
-    sequenceOf(
-        "machine-materials",
-        "machine-blockdata",
-    ).forEach {
-        implementation(files("/libs/$it.jar"))
-    }
-
     implementation(libs.machine.nbt)
     implementation(libs.machine.scriptive)
     implementation(libs.jetbrains.annotations) // overrides default compileOnly

--- a/api/src/main/java/org/machinemc/api/world/BlockData.java
+++ b/api/src/main/java/org/machinemc/api/world/BlockData.java
@@ -47,6 +47,12 @@ public abstract class BlockData implements Cloneable {
     }
 
     /**
+     * Registers the block data to the block data registry.
+     */
+    @ApiStatus.Internal
+    protected abstract void register();
+
+    /**
      * @return material of the block data
      */
     public abstract @Nullable Material getMaterial();
@@ -54,14 +60,6 @@ public abstract class BlockData implements Cloneable {
     /**
      * Changes base material for the block data and all its
      * variants.
-     * <p>
-     * For example changing material for oak log block data would
-     * change the returned value of {@link #getMaterial()} for all
-     * rotations of the oak log.
-     * <p>
-     * This can lead to unexpected behaviour because then
-     * {@code Material.OAK_LOG.createBlockData().getMaterial()} would return
-     * different material than the one it was created from.
      * @param material new material
      * @return this
      */

--- a/api/src/main/java/org/machinemc/api/world/BlockData.java
+++ b/api/src/main/java/org/machinemc/api/world/BlockData.java
@@ -14,11 +14,12 @@
  */
 package org.machinemc.api.world;
 
-import com.google.common.base.Objects;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
-import java.util.Arrays;
+import java.util.Map;
 
 /**
  * Visual data of a block, to create a new instance
@@ -38,6 +39,20 @@ public abstract class BlockData implements Cloneable {
     }
 
     /**
+     * Finishes the registration of the block data to materials.
+     */
+    @ApiStatus.Internal
+    public static void finishRegistration() {
+        BlockDataImpl.finishRegistration();
+    }
+
+    /**
+     * Registers the block data to the block data registry.
+     */
+    @ApiStatus.Internal
+    protected abstract void register();
+
+    /**
      * @return material of the block data
      */
     public abstract @Nullable Material getMaterial();
@@ -45,23 +60,12 @@ public abstract class BlockData implements Cloneable {
     /**
      * Changes base material for the block data and all its
      * variants.
-     * <p>
-     * Example: Changing material for oak log block data would
-     * change the base material for all rotations of the oak log.
      * @param material new material
      * @return this
      */
+    @ApiStatus.Internal
     @Contract("_ -> this")
     protected abstract BlockData setMaterial(Material material);
-
-    /**
-     * Returns id of the block data.
-     * @param blockData block data to get id from
-     * @return id of the given block data
-     */
-    public static int getId(final BlockData blockData) {
-        return BlockDataImpl.getId(blockData);
-    }
 
     /**
      * @return id of the block data used by Minecraft protocol
@@ -69,47 +73,22 @@ public abstract class BlockData implements Cloneable {
     public abstract int getId();
 
     /**
-     * Returns all data used by the block data (block data properties)
-     * in alphabetically order.
-     * @return block data properties
+     * Returns map of keys and values of all properties of this block data.
+     * Useful when creating data for block particles etc.
+     * @return map of block data properties
      */
-    protected abstract Object[] getData();
+    public abstract @Unmodifiable Map<String, String> getDataMap();
 
     /**
      * @return clone of this block data
      */
+    @Override
     public BlockData clone() {
         try {
             return (BlockData) super.clone();
         } catch (CloneNotSupportedException e) {
             return null;
         }
-    }
-
-    @Override
-    public String toString() {
-        if (getMaterial() != null)
-            return getMaterial().getName().getKey() + Arrays.toString(getData());
-        return "none" + Arrays.toString(getData());
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (!(o instanceof BlockData blockData)) return false;
-        if (getMaterial() != blockData.getMaterial()) return false;
-        final Object[] original = getData();
-        final Object[] compare = blockData.getData();
-        if (original.length != compare.length) return false;
-        for (int i = 0; i < original.length; i++) {
-            if (original[i] != compare[i]) return false;
-        }
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getMaterial(), getData());
     }
 
 }

--- a/api/src/main/java/org/machinemc/api/world/BlockData.java
+++ b/api/src/main/java/org/machinemc/api/world/BlockData.java
@@ -14,11 +14,12 @@
  */
 package org.machinemc.api.world;
 
-import com.google.common.base.Objects;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
-import java.util.Arrays;
+import java.util.Map;
 
 /**
  * Visual data of a block, to create a new instance
@@ -38,6 +39,14 @@ public abstract class BlockData implements Cloneable {
     }
 
     /**
+     * Finishes the registration of the block data to materials.
+     */
+    @ApiStatus.Internal
+    public static void finishRegistration() {
+        BlockDataImpl.finishRegistration();
+    }
+
+    /**
      * @return material of the block data
      */
     public abstract @Nullable Material getMaterial();
@@ -46,22 +55,19 @@ public abstract class BlockData implements Cloneable {
      * Changes base material for the block data and all its
      * variants.
      * <p>
-     * Example: Changing material for oak log block data would
-     * change the base material for all rotations of the oak log.
+     * For example changing material for oak log block data would
+     * change the returned value of {@link #getMaterial()} for all
+     * rotations of the oak log.
+     * <p>
+     * This can lead to unexpected behaviour because then
+     * {@code Material.OAK_LOG.createBlockData().getMaterial()} would return
+     * different material than the one it was created from.
      * @param material new material
      * @return this
      */
+    @ApiStatus.Internal
     @Contract("_ -> this")
     protected abstract BlockData setMaterial(Material material);
-
-    /**
-     * Returns id of the block data.
-     * @param blockData block data to get id from
-     * @return id of the given block data
-     */
-    public static int getId(final BlockData blockData) {
-        return BlockDataImpl.getId(blockData);
-    }
 
     /**
      * @return id of the block data used by Minecraft protocol
@@ -69,47 +75,22 @@ public abstract class BlockData implements Cloneable {
     public abstract int getId();
 
     /**
-     * Returns all data used by the block data (block data properties)
-     * in alphabetically order.
-     * @return block data properties
+     * Returns map of keys and values of all properties of this block data.
+     * Useful when creating data for block particles etc.
+     * @return map of block data properties
      */
-    protected abstract Object[] getData();
+    public abstract @Unmodifiable Map<String, String> getDataMap();
 
     /**
      * @return clone of this block data
      */
+    @Override
     public BlockData clone() {
         try {
             return (BlockData) super.clone();
         } catch (CloneNotSupportedException e) {
             return null;
         }
-    }
-
-    @Override
-    public String toString() {
-        if (getMaterial() != null)
-            return getMaterial().getName().getKey() + Arrays.toString(getData());
-        return "none" + Arrays.toString(getData());
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (!(o instanceof BlockData blockData)) return false;
-        if (getMaterial() != blockData.getMaterial()) return false;
-        final Object[] original = getData();
-        final Object[] compare = blockData.getData();
-        if (original.length != compare.length) return false;
-        for (int i = 0; i < original.length; i++) {
-            if (original[i] != compare[i]) return false;
-        }
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getMaterial(), getData());
     }
 
 }

--- a/api/src/main/java/org/machinemc/api/world/BlockDataImpl.java
+++ b/api/src/main/java/org/machinemc/api/world/BlockDataImpl.java
@@ -14,10 +14,9 @@
  */
 package org.machinemc.api.world;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
@@ -28,15 +27,14 @@ import java.util.*;
  * properties.
  */
 // This class is used by the code generators, edit with caution.
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class BlockDataImpl extends BlockData {
+class BlockDataImpl extends BlockData {
 
     private static final Map<Integer, BlockDataImpl> REGISTRY = new TreeMap<>();
     private static BlockDataImpl[] registryArray = new BlockDataImpl[0];
 
+    @Getter
     private Material material;
-    private int id;
+    private final int id;
 
     /**
      * Finishes the registration of the block data to materials.
@@ -53,24 +51,19 @@ public class BlockDataImpl extends BlockData {
      * @return new instance of the block data with the given id
      */
     public static @Nullable BlockData getBlockData(final int id) {
-        if (id == -1) return null;
+        if (id < 0) return null;
         if (registryArray.length <= id) return null;
         final BlockDataImpl data = registryArray[id];
         if (data == null) return null;
         return data.clone();
     }
 
-    /**
-     * Returns id of the block data.
-     * @param blockData block data to get id from
-     * @return id of the given block data
-     */
-    public static int getId(final BlockData blockData) {
-        return blockData.getId();
-    }
-
     protected BlockDataImpl(final int id) {
         this.id = id;
+    }
+
+    protected BlockDataImpl() {
+        this(-1);
     }
 
     @Override
@@ -87,9 +80,55 @@ public class BlockDataImpl extends BlockData {
         return this;
     }
 
+    /**
+     * Returns id of the block data.
+     * @param blockData block data to get id from
+     * @return id of the given block data
+     */
+    public static int getId(final BlockData blockData) {
+        return blockData.getId();
+    }
+
     @Override
-    protected Object[] getData() {
-        return new Object[0];
+    public int getId() {
+        if (id != -1) return id;
+
+        final Object[][] available = getAcceptedProperties();
+        final int[] weights = new int[available.length];
+
+        for (int i = 0; i < weights.length; i++) {
+            int weight = 1;
+            for (int j = i + 1; j < available.length; j++)
+                weight *= available[j].length;
+            weights[i] = weight;
+        }
+
+        final Object[] data = getData();
+        int id = firstStateID();
+
+        for (int i = 0; i < data.length; i++) {
+            int index = -1;
+            for (int j = 0; j < available[i].length; j++) {
+                if (available[i][j] != data[i]) continue;
+                index = j;
+                break;
+            }
+            assert index != -1;
+            id += weights[i] * index;
+        }
+
+        return id;
+    }
+
+    @Override
+    public @Unmodifiable Map<String, String> getDataMap() {
+        final Map<String, String> map = new LinkedHashMap<>();
+        final String[] names = getDataNames();
+        final Object[] data = getData();
+        assert names.length == data.length;
+        for (int i = 0; i < names.length; i++)
+            map.put(names[i], data[i].toString().toLowerCase());
+        return Collections.unmodifiableMap(map);
     }
 
     /**
@@ -97,6 +136,74 @@ public class BlockDataImpl extends BlockData {
      */
     protected @Unmodifiable Map<Integer, BlockData> getIdMap() {
         return Map.of(id, this);
+    }
+
+    /**
+     * Returns all data used by the block data (block data properties)
+     * in order of their names. {@link BlockDataImpl#getDataNames()}
+     * @return block data properties
+     */
+    protected Object[] getData() {
+        return new Object[0];
+    }
+
+    /**
+     * Returns all data keys used by the block data (block data properties)
+     * in order of Minecraft Protocol.
+     * @return keys of this block data
+     */
+    protected String[] getDataNames() {
+        return new String[0];
+    }
+
+    /**
+     * Returns all accepted properties values of this block data.
+     * <p>
+     * They are also mentioned in the BlockData class itself and
+     * marked with {@link PropertyRange}.
+     * <p>
+     * Their order needs to match the order in Minecraft Protocol;
+     * meaning groups match the order of their keys, {@link BlockDataImpl#getDataNames()}.
+     * <p>
+     * Elements of each group are sorted by Minecraft Protocol.
+     * @return accepted properties of this block data
+     */
+    protected Object[][] getAcceptedProperties() {
+        return new Object[0][];
+    }
+
+    /**
+     * Returns the id of the first state of this block data.
+     * <p>
+     * This is the lowest value of this block data.
+     * @return id of first state
+     */
+    protected int firstStateID() {
+        return id;
+    }
+
+    @Override
+    public String toString() {
+        if (getMaterial() != null)
+            return getMaterial().getName().getKey() + Arrays.toString(getData());
+        return "none" + Arrays.toString(getData());
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BlockData blockData)) return false;
+        if (getMaterial() != blockData.getMaterial()) return false;
+        final Map<String, String> original = getDataMap();
+        final Map<String, String> compare = getDataMap();
+        if (original.size() != compare.size()) return false;
+        return original.entrySet().stream()
+                .allMatch(e -> e.getValue().equals(compare.get(e.getKey())));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getMaterial(), getData());
     }
 
 }

--- a/api/src/main/java/org/machinemc/api/world/BlockDataImpl.java
+++ b/api/src/main/java/org/machinemc/api/world/BlockDataImpl.java
@@ -14,10 +14,9 @@
  */
 package org.machinemc.api.world;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
@@ -28,23 +27,24 @@ import java.util.*;
  * properties.
  */
 // This class is used by the code generators, edit with caution.
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class BlockDataImpl extends BlockData {
+class BlockDataImpl extends BlockData {
 
-    private static final Map<Integer, BlockDataImpl> REGISTRY = new TreeMap<>();
-    private static BlockDataImpl[] registryArray = new BlockDataImpl[0];
+    private static final Map<Integer, BlockDataImpl> TEMP_REGISTRY = new TreeMap<>();
+    private static BlockDataImpl[] registryArray;
 
+    @Getter
     private Material material;
-    private int id;
+    private final int id;
 
     /**
      * Finishes the registration of the block data to materials.
      */
     public static void finishRegistration() {
-        registryArray = new BlockDataImpl[Iterables.getLast(REGISTRY.keySet()) + 1];
-        for (final Integer stateId : REGISTRY.keySet())
-            registryArray[stateId] = REGISTRY.get(stateId);
+        canRegister();
+        registryArray = new BlockDataImpl[Iterables.getLast(TEMP_REGISTRY.keySet()) + 1];
+        for (final Integer stateId : TEMP_REGISTRY.keySet())
+            registryArray[stateId] = TEMP_REGISTRY.get(stateId);
+        TEMP_REGISTRY.clear();
     }
 
     /**
@@ -53,50 +53,208 @@ public class BlockDataImpl extends BlockData {
      * @return new instance of the block data with the given id
      */
     public static @Nullable BlockData getBlockData(final int id) {
-        if (id == -1) return null;
+        if (id < 0) return null;
         if (registryArray.length <= id) return null;
         final BlockDataImpl data = registryArray[id];
         if (data == null) return null;
-        return data.clone();
-    }
+        if (data.id != -1) return data.clone();
 
-    /**
-     * Returns id of the block data.
-     * @param blockData block data to get id from
-     * @return id of the given block data
-     */
-    public static int getId(final BlockData blockData) {
-        return blockData.getId();
+        final BlockDataImpl clone = (BlockDataImpl) data.clone();
+        final Object[][] available = clone.getAcceptedProperties();
+        final int[] weights = new int[available.length];
+
+        for (int i = 0; i < weights.length; i++) {
+            int weight = 1;
+            for (int j = i + 1; j < available.length; j++)
+                weight *= available[j].length;
+            weights[i] = weight;
+        }
+
+        final Object[] newData = new Object[available.length];
+        for (int i = 0; i < newData.length; i++)
+            newData[i] = available[i][0];
+
+        int diff = id - clone.firstStateID();
+        int i = 0;
+        while (diff != 0) {
+            final Object[] properties = available[i];
+            for (final Object property : properties) {
+                newData[i] = property;
+                diff -= weights[i];
+                if (diff < 0) {
+                    diff += weights[i];
+                    break;
+                }
+            }
+            i++;
+        }
+
+        clone.loadProperties(newData);
+        return clone;
     }
 
     protected BlockDataImpl(final int id) {
         this.id = id;
     }
 
+    protected BlockDataImpl() {
+        this(-1);
+    }
+
+    @Override
+    protected void register() {
+        canRegister();
+        if (id != -1) {
+            TEMP_REGISTRY.put(id, this);
+            return;
+        }
+
+        int id = firstStateID();
+        final Object[][] available = getAcceptedProperties();
+
+        for (int i = 0; i < available.length; i++) {
+            int weight = 1;
+            for (int j = i + 1; j < available.length; j++)
+                weight *= available[j].length;
+            id += weight * (available[i].length - 1);
+        }
+
+        for (int i = firstStateID(); i < id; i++) TEMP_REGISTRY.put(i, this);
+    }
+
+    /**
+     * Checks whether registrations of new block data are allowed.
+     * @throws UnsupportedOperationException if registrations had already finished
+     */
+    private static void canRegister() {
+        if (registryArray == null) return;
+        throw new UnsupportedOperationException("Registration has been already finished");
+    }
+
     @Override
     protected BlockDataImpl setMaterial(final Material material) {
         this.material = material;
-        final Map<Integer, BlockData> stateMap = getIdMap();
-        for (final Integer stateId : stateMap.keySet()) {
-            final BlockData data = stateMap.get(stateId).clone();
-            if (!(data instanceof BlockDataImpl blockData))
-                throw new IllegalStateException();
-            blockData.material = material;
-            REGISTRY.put(stateId, blockData);
-        }
         return this;
     }
 
     @Override
+    public int getId() {
+        if (id != -1) return id;
+
+        final Object[][] available = getAcceptedProperties();
+        final int[] weights = new int[available.length];
+
+        for (int i = 0; i < weights.length; i++) {
+            int weight = 1;
+            for (int j = i + 1; j < available.length; j++)
+                weight *= available[j].length;
+            weights[i] = weight;
+        }
+
+        final Object[] data = getData();
+        int id = firstStateID();
+
+        for (int i = 0; i < data.length; i++) {
+            int index = -1;
+            for (int j = 0; j < available[i].length; j++) {
+                if (available[i][j] != data[i]) continue;
+                index = j;
+                break;
+            }
+            assert index != -1;
+            id += weights[i] * index;
+        }
+
+        return id;
+    }
+
+    @Override
+    public @Unmodifiable Map<String, String> getDataMap() {
+        final Map<String, String> map = new LinkedHashMap<>();
+        final String[] names = getDataNames();
+        final Object[] data = getData();
+        assert names.length == data.length;
+        for (int i = 0; i < names.length; i++)
+            map.put(names[i], data[i].toString().toLowerCase());
+        return Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * Returns all data used by the block data (block data properties)
+     * in order of their names. {@link BlockDataImpl#getDataNames()}
+     * @return block data properties
+     */
     protected Object[] getData() {
         return new Object[0];
     }
 
     /**
-     * @return all block data states for material of this block data mapped to ids
+     * Returns all data keys used by the block data (block data properties)
+     * in order of Minecraft Protocol.
+     * @return keys of this block data
      */
-    protected @Unmodifiable Map<Integer, BlockData> getIdMap() {
-        return Map.of(id, this);
+    protected String[] getDataNames() {
+        return new String[0];
+    }
+
+    /**
+     * Returns all accepted properties values of this block data.
+     * <p>
+     * They are also mentioned in the BlockData class itself and
+     * marked with {@link PropertyRange}.
+     * <p>
+     * Their order needs to match the order in Minecraft Protocol;
+     * meaning groups match the order of their keys, {@link BlockDataImpl#getDataNames()}.
+     * <p>
+     * Elements of each group are sorted by Minecraft Protocol.
+     * @return accepted properties of this block data
+     */
+    protected Object[][] getAcceptedProperties() {
+        return new Object[0][];
+    }
+
+    /**
+     * Returns the id of the first state of this block data.
+     * <p>
+     * This is the lowest value of this block data.
+     * @return id of first state
+     */
+    protected int firstStateID() {
+        return id;
+    }
+
+    /**
+     * Loads properties to the block data, their order has to match
+     * the order of their keys, {@link BlockDataImpl#getDataNames()}.
+     * The array needs to provide all properties with correct types.
+     * @param properties properties to load
+     */
+    protected void loadProperties(final Object[] properties) {
+
+    }
+
+    @Override
+    public String toString() {
+        if (getMaterial() != null)
+            return getMaterial().getName().getKey() + Arrays.toString(getData());
+        return "none" + Arrays.toString(getData());
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BlockData blockData)) return false;
+        if (getMaterial() != blockData.getMaterial()) return false;
+        final Map<String, String> original = getDataMap();
+        final Map<String, String> compare = getDataMap();
+        if (original.size() != compare.size()) return false;
+        return original.entrySet().stream()
+                .allMatch(e -> e.getValue().equals(compare.get(e.getKey())));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getMaterial(), getData());
     }
 
 }

--- a/code-generators/src/main/java/org/machinemc/generators/CodeGenerator.java
+++ b/code-generators/src/main/java/org/machinemc/generators/CodeGenerator.java
@@ -116,9 +116,7 @@ public class CodeGenerator {
      * @return new class writer
      */
     public static ClassWriter createWriter() {
-        return new ClassWriter(
-                Opcodes.ASM9 | ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS
-        );
+        return new ClassWriter(Opcodes.ASM9 | ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
     }
 
     /**

--- a/code-generators/src/main/java/org/machinemc/generators/CodeGenerator.java
+++ b/code-generators/src/main/java/org/machinemc/generators/CodeGenerator.java
@@ -20,16 +20,19 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
+import org.objectweb.asm.*;
 
+import javax.annotation.processing.Generated;
 import java.io.*;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Date;
+import java.util.TimeZone;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-public class CodeGenerator {
+public abstract class CodeGenerator {
 
     public static final String PREFIX = "machine-";
     @Getter
@@ -40,34 +43,37 @@ public class CodeGenerator {
 
     protected ZipOutputStream zip;
     protected final JsonParser parser = new JsonParser();
+
+    @Getter
+    private final File jar;
+    private String jsonFile;
     @Getter(AccessLevel.PROTECTED) @Setter(AccessLevel.PROTECTED)
-    private JsonObject source;
+    private JsonObject json;
 
-    @Getter(AccessLevel.PROTECTED)
-    private boolean exists = false;
-
-    protected CodeGenerator(final @NotNull File outputDir, final String libraryName) throws IOException {
+    protected CodeGenerator(final @NotNull File outputDir, final String libraryName) {
         this.libraryName = libraryName;
-        final File jar = new File(outputDir.getPath() + "/" + PREFIX + libraryName + ".jar");
-        if (jar.exists()) {
-            exists = true;
-            return;
-        }
-        if (!jar.createNewFile())
-            throw new IOException("Failed to create the jar file for " + libraryName + " Machine Library");
-        zip = new ZipOutputStream(new FileOutputStream(jar));
-        source = null;
+        jar = new File(outputDir.getPath() + "/" + PREFIX + libraryName + ".jar");
     }
 
     protected CodeGenerator(final File outputDir,
                             final String libraryName,
-                            final String jsonFile) throws IOException {
+                            final String jsonFile) {
         this(outputDir, libraryName);
-        if (exists) return;
+        this.jsonFile = jsonFile;
+    }
+
+    /**
+     * Loads the json and zip stream for the generator.
+     */
+    public void load() throws Throwable {
+        if (!jar.exists() && !jar.createNewFile())
+            throw new IOException("Failed to create the jar file for " + libraryName + " Machine Library");
+        zip = new ZipOutputStream(new FileOutputStream(jar));
+        if (jsonFile == null) return;
         final InputStream stream = getClass().getClassLoader().getResourceAsStream(jsonFile);
         if (stream == null)
             throw new FileNotFoundException();
-        source = parser.parse(new InputStreamReader(stream)).getAsJsonObject();
+        json = parser.parse(new InputStreamReader(stream)).getAsJsonObject();
     }
 
     /**
@@ -95,7 +101,7 @@ public class CodeGenerator {
      * @param dotPath dot path
      * @return type
      */
-    public Type type(final @NotNull String dotPath) {
+    public static Type type(final @NotNull String dotPath) {
         return Type.getType("L" + dotPath.replace(".", "/") + ";");
     }
 
@@ -104,7 +110,7 @@ public class CodeGenerator {
      * @param type type
      * @return array type
      */
-    public Type array(final @NotNull Type type) {
+    public static Type array(final @NotNull Type type) {
         return Type.getType("[" + type.getDescriptor());
     }
 
@@ -112,10 +118,8 @@ public class CodeGenerator {
      * Creates new class writer with default options.
      * @return new class writer
      */
-    public ClassWriter createWriter() {
-        return new ClassWriter(
-                Opcodes.ASM9 | ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS
-        );
+    public static ClassWriter createWriter() {
+        return new ClassWriter(Opcodes.ASM9 | ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
     }
 
     /**
@@ -123,7 +127,7 @@ public class CodeGenerator {
      * @param mv visitor
      * @param o value
      */
-    public void pushValue(final MethodVisitor mv, final Object o) {
+    public static void pushValue(final MethodVisitor mv, final Object o) {
         int value;
         if (o instanceof Boolean)
             value = (Boolean) o ? 1 : 0;
@@ -143,6 +147,52 @@ public class CodeGenerator {
             mv.visitIntInsn(Opcodes.SIPUSH, value);
         else
             mv.visitLdcInsn(value);
+    }
+
+    /**
+     * Visits the generated annotation for the class visitor.
+     * @param cv class visitor
+     * @param codeGenerator code generator that generated the annotated class
+     */
+    public static void visitGeneratedAnnotation(final ClassVisitor cv,
+                                                final Class<? extends CodeGenerator> codeGenerator) {
+        final AnnotationVisitor av = cv.visitAnnotation(Type.getType(Generated.class).getDescriptor(), true);
+
+        final AnnotationVisitor valueVisitor = av.visitArray("value");
+        valueVisitor.visit("0", codeGenerator.getName());
+        valueVisitor.visitEnd();
+
+        final TimeZone tz = TimeZone.getTimeZone("UTC");
+        final DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+        df.setTimeZone(tz);
+        av.visit("date", df.format(Date.from(Instant.now())));
+
+        av.visitEnd();
+    }
+
+    /**
+     * Converts string to camel case.
+     * @param text text to convert
+     * @param capitalizeFirst whether the first letter should be capitalize
+     * @return camel case text
+     */
+    public static String toCamelCase(final String text, final boolean capitalizeFirst) {
+        final String[] words = text.split("[\\W_]+");
+        final StringBuilder builder = new StringBuilder();
+        boolean capitalize = capitalizeFirst;
+        for (final String word : words) {
+            final String formattedWord;
+            if (capitalize)
+                formattedWord = word.isEmpty()
+                        ? word
+                        : Character.toUpperCase(word.charAt(0)) + word.substring(1).toLowerCase();
+            else {
+                formattedWord = word.toLowerCase();
+                capitalize = true;
+            }
+            builder.append(formattedWord);
+        }
+        return builder.toString();
     }
 
 }

--- a/code-generators/src/main/java/org/machinemc/generators/Generators.java
+++ b/code-generators/src/main/java/org/machinemc/generators/Generators.java
@@ -14,17 +14,25 @@
  */
 package org.machinemc.generators;
 
+import com.google.gson.*;
+import lombok.RequiredArgsConstructor;
+import org.apache.tools.ant.filters.StringInputStream;
 import org.machinemc.generators.blockdata.BlockDataLibGenerator;
 import org.machinemc.generators.materials.MaterialsLibGenerator;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
+@RequiredArgsConstructor
 public final class Generators {
 
-    private Generators() {
-        throw new UnsupportedOperationException();
-    }
+    private final File projectDir;
+
+    private JsonObject versions;
+    private JsonObject userVersions;
+
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     /**
      * Runs the generators in a provided directory.
@@ -32,20 +40,70 @@ public final class Generators {
      */
     public static void run(final File projectDir) {
         try {
-            if (projectDir.isFile()) return;
-            final File outputDir = new File(projectDir.getPath() + "/libs");
-            if (!outputDir.exists() && !outputDir.mkdirs())
-                throw new IOException("Folder for Machine libraries could not be created");
-
-            final CodeGenerator materials = new MaterialsLibGenerator(outputDir);
-            if (!materials.isExists()) materials.generate();
-
-            final CodeGenerator blockdata = new BlockDataLibGenerator(outputDir);
-            if (!blockdata.isExists()) blockdata.generate();
-
-        } catch (Exception exception) {
+            new Generators(projectDir).run0();
+        } catch (Throwable throwable) {
             System.out.println("Machine Library Generator unexpectedly ended.");
-            exception.printStackTrace();
+            throw new RuntimeException(throwable);
+        }
+    }
+
+    private void run0() throws Throwable {
+        if (projectDir.isFile()) return;
+        final File outputDir = new File(projectDir.getPath() + "/libs");
+        if (!outputDir.exists() && !outputDir.mkdirs())
+            throw new IOException("Folder for Machine libraries could not be created");
+
+        final File versionsFile = new File(outputDir, "versions.json");
+        final InputStream is = getClass().getClassLoader().getResourceAsStream("versions.json");
+        final byte[] data;
+        try (is) {
+            if (is == null) throw new NullPointerException();
+            data = is.readAllBytes();
+        }
+
+        versions = new JsonParser().parse(
+                new InputStreamReader(new ByteArrayInputStream(data))
+        ).getAsJsonObject();
+
+        final boolean regenerate;
+
+        if (!versionsFile.exists()) {
+            if (!versionsFile.createNewFile())
+                throw new IOException("Versions file for Machine libraries could not be created");
+            Files.copy(new ByteArrayInputStream(data), versionsFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            regenerate = true;
+        } else {
+            regenerate = false;
+        }
+
+        final InputStreamReader reader = new InputStreamReader(new FileInputStream(versionsFile));
+        try (reader) {
+            userVersions = new JsonParser().parse(reader).getAsJsonObject();
+        }
+
+        handle(new MaterialsLibGenerator(outputDir), regenerate);
+        handle(new BlockDataLibGenerator(outputDir), regenerate);
+
+        Files.copy(new StringInputStream(gson.toJson(userVersions)),
+                versionsFile.toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private void handle(final CodeGenerator generator, final boolean regenerate) throws Throwable {
+        if (!generator.getJar().exists()) {
+            generator.load();
+            generator.generate();
+            return;
+        }
+        final String version = versions.get(generator.getLibraryName()).getAsString();
+        final JsonElement element = userVersions.get(generator.getLibraryName());
+        final String userVersion = element != null ? element.getAsString() : null;
+        if (!version.equals(userVersion) || regenerate) {
+            if (!generator.getJar().delete() || !generator.getJar().createNewFile())
+                throw new IOException(generator.getLibraryName() + " Machine library could not be recreated");
+            generator.load();
+            generator.generate();
+            userVersions.addProperty(generator.getLibraryName(), version);
         }
     }
 

--- a/code-generators/src/main/java/org/machinemc/generators/Generators.java
+++ b/code-generators/src/main/java/org/machinemc/generators/Generators.java
@@ -32,21 +32,24 @@ public final class Generators {
      */
     public static void run(final File projectDir) {
         try {
-            if (projectDir.isFile()) return;
-            final File outputDir = new File(projectDir.getPath() + "/libs");
-            if (!outputDir.exists() && !outputDir.mkdirs())
-                throw new IOException("Folder for Machine libraries could not be created");
-
-            final CodeGenerator materials = new MaterialsLibGenerator(outputDir);
-            if (!materials.isExists()) materials.generate();
-
-            final CodeGenerator blockdata = new BlockDataLibGenerator(outputDir);
-            if (!blockdata.isExists()) blockdata.generate();
-
+            run0(projectDir);
         } catch (Throwable throwable) {
             System.out.println("Machine Library Generator unexpectedly ended.");
             throw new RuntimeException(throwable);
         }
+    }
+
+    private static void run0(final File projectDir) throws Throwable {
+        if (projectDir.isFile()) return;
+        final File outputDir = new File(projectDir.getPath() + "/libs");
+        if (!outputDir.exists() && !outputDir.mkdirs())
+            throw new IOException("Folder for Machine libraries could not be created");
+
+        final CodeGenerator materials = new MaterialsLibGenerator(outputDir);
+        if (!materials.isExists()) materials.generate();
+
+        final CodeGenerator blockdata = new BlockDataLibGenerator(outputDir);
+        if (!blockdata.isExists()) blockdata.generate();
     }
 
 }

--- a/code-generators/src/main/java/org/machinemc/generators/Generators.java
+++ b/code-generators/src/main/java/org/machinemc/generators/Generators.java
@@ -14,17 +14,25 @@
  */
 package org.machinemc.generators;
 
+import com.google.gson.*;
+import lombok.RequiredArgsConstructor;
+import org.apache.tools.ant.filters.StringInputStream;
 import org.machinemc.generators.blockdata.BlockDataLibGenerator;
 import org.machinemc.generators.materials.MaterialsLibGenerator;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
+@RequiredArgsConstructor
 public final class Generators {
 
-    private Generators() {
-        throw new UnsupportedOperationException();
-    }
+    private final File projectDir;
+
+    private JsonObject versions;
+    private JsonObject userVersions;
+
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     /**
      * Runs the generators in a provided directory.
@@ -32,24 +40,71 @@ public final class Generators {
      */
     public static void run(final File projectDir) {
         try {
-            run0(projectDir);
+            new Generators(projectDir).run0();
         } catch (Throwable throwable) {
             System.out.println("Machine Library Generator unexpectedly ended.");
             throw new RuntimeException(throwable);
         }
     }
 
-    private static void run0(final File projectDir) throws Throwable {
+    private void run0() throws Throwable {
         if (projectDir.isFile()) return;
         final File outputDir = new File(projectDir.getPath() + "/libs");
         if (!outputDir.exists() && !outputDir.mkdirs())
             throw new IOException("Folder for Machine libraries could not be created");
 
-        final CodeGenerator materials = new MaterialsLibGenerator(outputDir);
-        if (!materials.isExists()) materials.generate();
+        final File versionsFile = new File(outputDir, "versions.json");
+        final InputStream is = getClass().getClassLoader().getResourceAsStream("versions.json");
+        final byte[] data;
+        try (is) {
+            if (is == null) throw new NullPointerException();
+            data = is.readAllBytes();
+        }
 
-        final CodeGenerator blockdata = new BlockDataLibGenerator(outputDir);
-        if (!blockdata.isExists()) blockdata.generate();
+        versions = new JsonParser().parse(
+                new InputStreamReader(new ByteArrayInputStream(data))
+        ).getAsJsonObject();
+
+        final boolean regenerate;
+
+        if (!versionsFile.exists()) {
+            if (!versionsFile.createNewFile())
+                throw new IOException("Versions file for Machine libraries could not be created");
+            Files.copy(new ByteArrayInputStream(data), versionsFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            regenerate = true;
+        } else {
+            regenerate = false;
+        }
+
+        final InputStreamReader reader = new InputStreamReader(new FileInputStream(versionsFile));
+        try (reader) {
+            userVersions = new JsonParser().parse(reader).getAsJsonObject();
+        }
+
+        handle(new MaterialsLibGenerator(outputDir), regenerate);
+        handle(new BlockDataLibGenerator(outputDir), regenerate);
+
+        Files.copy(new StringInputStream(gson.toJson(userVersions)),
+                versionsFile.toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private void handle(final CodeGenerator generator, final boolean regenerate) throws Throwable {
+        if (!generator.getJar().exists()) {
+            generator.load();
+            generator.generate();
+            return;
+        }
+        final String version = versions.get(generator.getLibraryName()).getAsString();
+        final JsonElement element = userVersions.get(generator.getLibraryName());
+        final String userVersion = element != null ? element.getAsString() : null;
+        if (!version.equals(userVersion) || regenerate) {
+            if (!generator.getJar().delete() || !generator.getJar().createNewFile())
+                throw new IOException(generator.getLibraryName() + " Machine library could not be recreated");
+            generator.load();
+            generator.generate();
+            userVersions.addProperty(generator.getLibraryName(), version);
+        }
     }
 
 }

--- a/code-generators/src/main/java/org/machinemc/generators/Generators.java
+++ b/code-generators/src/main/java/org/machinemc/generators/Generators.java
@@ -43,9 +43,9 @@ public final class Generators {
             final CodeGenerator blockdata = new BlockDataLibGenerator(outputDir);
             if (!blockdata.isExists()) blockdata.generate();
 
-        } catch (Exception exception) {
+        } catch (Throwable throwable) {
             System.out.println("Machine Library Generator unexpectedly ended.");
-            exception.printStackTrace();
+            throw new RuntimeException(throwable);
         }
     }
 

--- a/code-generators/src/main/java/org/machinemc/generators/blockdata/BlockData.java
+++ b/code-generators/src/main/java/org/machinemc/generators/blockdata/BlockData.java
@@ -427,7 +427,7 @@ public final class BlockData {
         // loadProperties method
         mv = cw.visitMethod(Opcodes.ACC_PROTECTED,
                 "loadProperties",
-                "(" + Type.getType(Object[].class).getDescriptor() + ")V",
+                "([Ljava/lang/Object;)V",
                 null,
                 new String[0]);
         mv.visitAnnotation(Type.getType(Override.class).getDescriptor(), true).visitEnd();

--- a/code-generators/src/main/java/org/machinemc/generators/blockdata/BlockData.java
+++ b/code-generators/src/main/java/org/machinemc/generators/blockdata/BlockData.java
@@ -18,11 +18,13 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import lombok.Getter;
+import org.jetbrains.annotations.Nullable;
+import org.machinemc.generators.CodeGenerator;
 import org.objectweb.asm.*;
 
 import java.util.*;
 
-import static org.machinemc.generators.blockdata.BlockDataLibGenerator.toCamelCase;
+import static org.machinemc.generators.CodeGenerator.*;
 
 public final class BlockData {
 
@@ -31,23 +33,22 @@ public final class BlockData {
 
     @Getter
     private final String name;
-    private final String id;
 
     // Linked HashMaps are important, system depends on order!
-    private Set<Property> properties                    = new LinkedHashSet<>();
-    private Map<Property, List<String>> availableValues = new LinkedHashMap<>();
-    private Map<String, Integer> idMap                  = new LinkedHashMap<>();
+    private Set<Property> properties                    = new LinkedHashSet<>(); // used properties by this block data
+    private Map<Property, List<String>> availableValues = new LinkedHashMap<>(); // available values for the properties
 
-    private Map<Integer, List<Map.Entry<Property, String>>> blockDataMap = new LinkedHashMap<>();
+    private BlockDataGroup[] groups = new BlockDataGroup[0];
 
     private Map<Property, String> defaultState = new HashMap<>();
+
+    private int startingState = -1;
 
     @Getter
     private final String path;
 
     private BlockData(final String id) {
         this.name = toCamelCase(id.replaceFirst("minecraft:", ""), true);
-        this.id = id;
         path = "org.machinemc.api.world." + this.name + "Data";
     }
 
@@ -56,23 +57,26 @@ public final class BlockData {
      * @param generator generator to use
      * @param name name of the block data
      * @param json json report file
+     * @param groups groups of the block data
      * @return block data
      */
-    public static BlockData create(final BlockDataLibGenerator generator, final String name, final JsonObject json) {
+    public static BlockData create(final BlockDataLibGenerator generator,
+                                   final String name,
+                                   final JsonObject json,
+                                   final @Nullable BlockDataGroup[] groups) {
         if (json.get("properties") == null) return null;
 
         // Linked HashMaps are important, system depends on order!
         final Set<Property> properties                    = new LinkedHashSet<>();
         final Map<Property, List<String>> availableValues = new LinkedHashMap<>();
-        final Map<String, Integer> idMap                  = new LinkedHashMap<>();
-
-        final Map<Integer, List<Map.Entry<Property, String>>> blockDataMap = new LinkedHashMap<>();
 
         final Map<Property, String> defaultState = new HashMap<>();
 
+        int startingState = -1;
+
         final JsonObject jsonProperties = json.get("properties").getAsJsonObject();
         for (final Map.Entry<String, JsonElement> entry : jsonProperties.entrySet()) {
-            final Property property = generator.getProperties().get(toCamelCase(entry.getKey(), true));
+            final Property property = generator.getProperties().get(entry.getKey());
             properties.add(property);
             availableValues.put(property, new ArrayList<>());
             jsonProperties.get(entry.getKey()).getAsJsonArray()
@@ -83,30 +87,30 @@ public final class BlockData {
         final JsonArray jsonStates = json.get("states").getAsJsonArray();
         for (final JsonElement stateElement : jsonStates) {
             final int stateId = stateElement.getAsJsonObject().get("id").getAsInt();
-            blockDataMap.put(stateId, new ArrayList<>());
+            if (stateId < startingState || startingState == -1)
+                startingState = stateId;
             final boolean isDefault = stateElement.getAsJsonObject().get("default") != null;
             final JsonObject stateProperties = stateElement.getAsJsonObject().get("properties").getAsJsonObject();
-            final StringBuilder key = new StringBuilder();
-            for (final Map.Entry<String, JsonElement> entry : stateProperties.entrySet()) {
-                key.append(entry.getValue().getAsString());
-                key.append(";");
-                final Property property = generator.getProperties().get(toCamelCase(entry.getKey(), true));
-                blockDataMap.get(stateId).add(new AbstractMap.SimpleEntry<>(property, entry.getValue().getAsString()));
-                if (isDefault)
-                    defaultState.put(property, entry.getValue().getAsString());
+            if (isDefault) {
+                for (final Map.Entry<String, JsonElement> entry : stateProperties.entrySet())
+                    defaultState.put(
+                            generator.getProperties().get(entry.getKey()),
+                            entry.getValue().getAsString()
+                    );
             }
-            idMap.put(key.toString().toLowerCase(), stateId);
         }
 
         final BlockData blockData = new BlockData(name);
 
         blockData.properties      = properties;
         blockData.availableValues = availableValues;
-        blockData.idMap           = idMap;
 
-        blockData.blockDataMap = blockDataMap;
+        if (groups != null)
+            blockData.groups = groups;
 
         blockData.defaultState = defaultState;
+
+        blockData.startingState = startingState;
         return blockData;
     }
 
@@ -115,37 +119,28 @@ public final class BlockData {
      * @return data for the block data class
      */
     public byte[] generate() {
-        final ClassWriter cw = new ClassWriter(Opcodes.ASM9 | ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+        final ClassWriter cw = createWriter();
         final Set<String> interfaces = new LinkedHashSet<>();
         for (final Property property : properties)
-            interfaces.add(property.getInterfacePath().replaceAll("\\.", "/"));
+            interfaces.add(type(property.getInterfacePath()).getInternalName());
+        for (final BlockDataGroup group : groups)
+            interfaces.add(type(group.getPath()).getInternalName());
         cw.visit(Opcodes.V17,
-                Opcodes.ACC_PUBLIC,
+                Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL,
                 type(path).getInternalName(),
                 null,
                 type(BLOCKDATA_CLASS).getInternalName(),
                 interfaces.toArray(new String[0]));
+        CodeGenerator.visitGeneratedAnnotation(cw, BlockDataLibGenerator.class);
 
         // Fields
-        FieldVisitor fv = cw.visitField(Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL,
-                "ID_MAP",
-                Type.getType(HashMap.class).getDescriptor(),
-                "Ljava/util/HashMap<Ljava/lang/String;Ljava/lang/Integer;>;",
-                null);
-        fv.visitEnd();
-        fv = cw.visitField(Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL,
-                "BLOCKDATA_MAP",
-                Type.getType(HashMap.class).getDescriptor(),
-                "Ljava/util/HashMap<Ljava/lang/Integer;" + type(path).getDescriptor() + ">;",
-                null);
-        fv.visitEnd();
         for (final Property property : properties) {
             final String descriptor = switch (property.getType()) {
                 case BOOLEAN -> Type.BOOLEAN_TYPE.getDescriptor();
                 case NUMBER -> Type.INT_TYPE.getDescriptor();
                 case OTHER -> type(property.getPath()).getDescriptor();
             };
-            fv = cw.visitField(Opcodes.ACC_PRIVATE,
+            final FieldVisitor fv = cw.visitField(Opcodes.ACC_PRIVATE,
                     toCamelCase(property.getName(), false),
                     descriptor,
                     null,
@@ -161,7 +156,7 @@ public final class BlockData {
             cw.visitEnd();
             // Getter
             MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC,
-                    "get" + toCamelCase(property.getName(), true),
+                    "get" + property.getFormattedName(),
                     "()" + descriptor,
                     null,
                     new String[0]);
@@ -183,7 +178,7 @@ public final class BlockData {
             cw.visitEnd();
             // Setter
             mv = cw.visitMethod(Opcodes.ACC_PUBLIC,
-                    "set" + toCamelCase(property.getName(), true),
+                    "set" + property.getFormattedName(),
                     "(" + descriptor + ")" + type(path).getDescriptor(),
                     null,
                     new String[0]);
@@ -208,7 +203,7 @@ public final class BlockData {
         }
 
         // Constructor
-        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PROTECTED,
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC,
                 "<init>",
                 "()V",
                 null,
@@ -255,7 +250,7 @@ public final class BlockData {
                         case OTHER -> type(property.getPath()).getDescriptor();
             });
         descriptorBuilder.append(")V");
-        mv = cw.visitMethod(Opcodes.ACC_PROTECTED,
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC,
                 "<init>",
                 descriptorBuilder.toString(),
                 null,
@@ -284,106 +279,6 @@ public final class BlockData {
                         case OTHER -> type(property.getPath()).getDescriptor();
                     });
             i++;
-        }
-        mv.visitInsn(Opcodes.RETURN);
-        mv.visitMaxs(0, 0);
-        mv.visitEnd();
-        cw.visitEnd();
-
-        // Static block
-        mv = cw.visitMethod(Opcodes.ACC_STATIC,
-                "<clinit>",
-                "()V",
-                null,
-                new String[0]);
-        mv.visitCode();
-        i = 0;
-        for (final String fieldName : List.of("ID_MAP", "BLOCKDATA_MAP")) {
-            mv.visitTypeInsn(Opcodes.NEW, Type.getType(HashMap.class).getInternalName());
-            mv.visitInsn(Opcodes.DUP);
-            mv.visitMethodInsn(Opcodes.INVOKESPECIAL,
-                    Type.getType(HashMap.class).getInternalName(),
-                    "<init>",
-                    "()V",
-                    false);
-            mv.visitVarInsn(Opcodes.ASTORE, i);
-            mv.visitVarInsn(Opcodes.ALOAD, i);
-            mv.visitFieldInsn(Opcodes.PUTSTATIC,
-                    type(path).getInternalName(),
-                    fieldName,
-                    Type.getType(HashMap.class).getDescriptor());
-            i++;
-        }
-        for (final String key : idMap.keySet()) {
-            mv.visitVarInsn(Opcodes.ALOAD, 0);
-            pushValue(mv, key);
-            pushValue(mv, idMap.get(key));
-            mv.visitMethodInsn(Opcodes.INVOKESTATIC,
-                    Type.getType(Integer.class).getInternalName(),
-                    "valueOf",
-                    "(I)Ljava/lang/Integer;",
-                    false);
-            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
-                    Type.getType(HashMap.class).getInternalName(),
-                    "put",
-                    "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
-                    false);
-            mv.visitInsn(Opcodes.POP);
-        }
-        mv.visitMethodInsn(Opcodes.INVOKESTATIC,
-                type(path).getInternalName(),
-                "initBlockDataMap",
-                "()V",
-                false);
-        mv.visitInsn(Opcodes.RETURN);
-        mv.visitMaxs(0, 0);
-        mv.visitEnd();
-        cw.visitEnd();
-
-        // Init block data map method
-        mv = cw.visitMethod(Opcodes.ACC_PROTECTED | Opcodes.ACC_STATIC,
-                "initBlockDataMap",
-                "()V",
-                null,
-                new String[0]);
-        mv.visitCode();
-        for (final Integer id : blockDataMap.keySet()) {
-            mv.visitFieldInsn(Opcodes.GETSTATIC,
-                    type(path).getInternalName(),
-                    "BLOCKDATA_MAP",
-                    Type.getType(HashMap.class).getDescriptor());
-            final StringBuilder stateKeyBuilder = new StringBuilder();
-            for (final Map.Entry<Property, String> property : blockDataMap.get(id))
-                stateKeyBuilder.append(property.getValue().toLowerCase()).append(";");
-            pushValue(mv, idMap.get(stateKeyBuilder.toString()));
-            mv.visitMethodInsn(Opcodes.INVOKESTATIC,
-                    Type.getType(Integer.class).getInternalName(),
-                    "valueOf",
-                    "(I)Ljava/lang/Integer;",
-                    false);
-            mv.visitTypeInsn(Opcodes.NEW, type(path).getInternalName());
-            mv.visitInsn(Opcodes.DUP);
-            for (final Map.Entry<Property, String> property : blockDataMap.get(id)) {
-                switch (property.getKey().getType()) {
-                    case BOOLEAN -> pushValue(mv, Boolean.parseBoolean(property.getValue()));
-                    case NUMBER -> pushValue(mv, Integer.parseInt(property.getValue()));
-                    case OTHER -> mv.visitFieldInsn(Opcodes.GETSTATIC,
-                            type(property.getKey().getPath()).getInternalName(),
-                            property.getValue().toUpperCase(),
-                            type(property.getKey().getPath()).getDescriptor());
-                }
-            }
-            mv.visitMethodInsn(Opcodes.INVOKESPECIAL,
-                    type(path).getInternalName(),
-                    "<init>",
-                    descriptorBuilder.toString(),
-                    false);
-            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
-                    Type.getType(HashMap.class).getInternalName(),
-                    "put",
-                    "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
-                    false);
-            mv.visitInsn(Opcodes.POP);
         }
         mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(0, 0);
@@ -434,133 +329,157 @@ public final class BlockData {
         mv.visitEnd();
         cw.visitEnd();
 
+        // getDataNames method
         mv = cw.visitMethod(Opcodes.ACC_PROTECTED,
-                "getIdMap",
-                "()" + Type.getType(Map.class).getDescriptor(),
+                "getDataNames",
+                "()[Ljava/lang/String;",
                 null,
                 new String[0]);
         mv.visitAnnotation(Type.getType(Override.class).getDescriptor(), true).visitEnd();
         mv.visitEnd();
         mv.visitCode();
-        mv.visitFieldInsn(Opcodes.GETSTATIC,
-                type(path).getInternalName(),
-                "BLOCKDATA_MAP",
-                Type.getType(HashMap.class).getDescriptor());
+        pushValue(mv, properties.size());
+        mv.visitTypeInsn(Opcodes.ANEWARRAY, Type.getType(String.class).getInternalName());
+        i = 0;
+        for (final Property property : properties) {
+            mv.visitInsn(Opcodes.DUP);
+            pushValue(mv, i);
+            pushValue(mv, property.getName());
+            mv.visitInsn(Opcodes.AASTORE);
+            i++;
+        }
         mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(0, 0);
         mv.visitEnd();
         cw.visitEnd();
 
-        // getId method
-        mv = cw.visitMethod(Opcodes.ACC_PUBLIC,
-                "getId",
+        // getAcceptedProperties method
+        mv = cw.visitMethod(Opcodes.ACC_PROTECTED,
+                "getAcceptedProperties",
+                "()[[Ljava/lang/Object;",
+                null,
+                new String[0]);
+        mv.visitAnnotation(Type.getType(Override.class).getDescriptor(), true).visitEnd();
+        mv.visitEnd();
+        mv.visitCode();
+        pushValue(mv, properties.size());
+        mv.visitTypeInsn(Opcodes.ANEWARRAY, Type.getType(Object[].class).getInternalName());
+        i = 0;
+        for (final Property property : properties) {
+            mv.visitInsn(Opcodes.DUP);
+            pushValue(mv, i);
+
+            final List<String> available = availableValues.get(property);
+            pushValue(mv, available.size());
+            mv.visitTypeInsn(Opcodes.ANEWARRAY, Type.getType(Object.class).getInternalName());
+            for (int j = 0; j < available.size(); j++) {
+                final String value = available.get(j);
+                mv.visitInsn(Opcodes.DUP);
+                pushValue(mv, j);
+                switch (property.getType()) {
+                    case BOOLEAN -> {
+                        pushValue(mv, Boolean.parseBoolean(value));
+                        mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                                Type.getType(Boolean.class).getInternalName(),
+                                "valueOf",
+                                "(Z)Ljava/lang/Boolean;",
+                                false);
+                    }
+                    case NUMBER -> {
+                        pushValue(mv, Integer.parseInt(value));
+                        mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                                Type.getType(Integer.class).getInternalName(),
+                                "valueOf",
+                                "(I)Ljava/lang/Integer;",
+                                false);
+                    }
+                    case OTHER -> mv.visitFieldInsn(Opcodes.GETSTATIC,
+                            type(property.getPath()).getInternalName(),
+                            value,
+                            type(property.getPath()).getDescriptor());
+                }
+                mv.visitInsn(Opcodes.AASTORE);
+            }
+
+            mv.visitInsn(Opcodes.AASTORE);
+            i++;
+        }
+        mv.visitInsn(Opcodes.ARETURN);
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+        cw.visitEnd();
+
+        // firstStateID method
+        mv = cw.visitMethod(Opcodes.ACC_PROTECTED,
+                "firstStateID",
                 "()I",
                 null,
                 new String[0]);
         mv.visitAnnotation(Type.getType(Override.class).getDescriptor(), true).visitEnd();
         mv.visitEnd();
         mv.visitCode();
-        mv.visitFieldInsn(Opcodes.GETSTATIC,
-                type(path).getInternalName(),
-                "ID_MAP",
-                Type.getType(HashMap.class).getDescriptor());
-        mv.visitTypeInsn(Opcodes.NEW, Type.getType(StringBuilder.class).getInternalName());
-        mv.visitInsn(Opcodes.DUP);
-        mv.visitMethodInsn(Opcodes.INVOKESPECIAL,
-                Type.getType(StringBuilder.class).getInternalName(),
-                "<init>",
-                "()V",
-                false);
-        for (final Property property : properties) {
-            mv.visitVarInsn(Opcodes.ALOAD, 0);
-            mv.visitFieldInsn(Opcodes.GETFIELD,
-                    type(path).getInternalName(),
-                    toCamelCase(property.getName(), false),
-                    switch (property.getType()) {
-                        case BOOLEAN -> Type.BOOLEAN_TYPE.getDescriptor();
-                        case NUMBER -> Type.INT_TYPE.getDescriptor();
-                        case OTHER -> type(property.getPath()).getDescriptor();
-                    });
-            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
-                    Type.getType(StringBuilder.class).getInternalName(),
-                    "append",
-                    "(" + switch (property.getType()) {
-                        case BOOLEAN -> Type.BOOLEAN_TYPE.getDescriptor();
-                        case NUMBER -> Type.INT_TYPE.getDescriptor();
-                        case OTHER -> Type.getType(Object.class).getDescriptor();
-                    } + ")Ljava/lang/StringBuilder;",
-                    false);
-            pushValue(mv, ";");
-            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
-                    Type.getType(StringBuilder.class).getInternalName(),
-                    "append",
-                    "(Ljava/lang/String;)Ljava/lang/StringBuilder;",
-                    false);
-        }
-        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
-                Type.getType(StringBuilder.class).getInternalName(),
-                "toString",
-                "()Ljava/lang/String;",
-                false);
-        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
-                Type.getType(String.class).getInternalName(),
-                "toLowerCase",
-                "()Ljava/lang/String;",
-                false);
-        mv.visitLdcInsn(0);
-        mv.visitMethodInsn(Opcodes.INVOKESTATIC,
-                Type.getType(Integer.class).getInternalName(),
-                "valueOf",
-                "(I)Ljava/lang/Integer;",
-                false);
-        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
-                Type.getType(HashMap.class).getInternalName(),
-                "getOrDefault",
-                "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
-                false);
-        mv.visitTypeInsn(Opcodes.CHECKCAST, Type.getType(Integer.class).getInternalName());
-        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
-                Type.getType(Integer.class).getInternalName(),
-                "intValue",
-                "()I",
-                false);
+        pushValue(mv, startingState);
         mv.visitInsn(Opcodes.IRETURN);
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+        cw.visitEnd();
+
+        // loadProperties method
+        mv = cw.visitMethod(Opcodes.ACC_PROTECTED,
+                "loadProperties",
+                "([Ljava/lang/Object;)V",
+                null,
+                new String[0]);
+        mv.visitAnnotation(Type.getType(Override.class).getDescriptor(), true).visitEnd();
+        mv.visitEnd();
+        mv.visitCode();
+
+        int j = 0;
+        for (final Property property : properties) {
+
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitVarInsn(Opcodes.ALOAD, 1);
+            pushValue(mv, j);
+            mv.visitInsn(Opcodes.AALOAD);
+            mv.visitTypeInsn(Opcodes.CHECKCAST, (
+                    switch (property.getType()) {
+                        case BOOLEAN -> Type.getType(Boolean.class);
+                        case NUMBER -> Type.getType(Integer.class);
+                        case OTHER -> type(property.getPath()); }
+            ).getInternalName());
+
+            if (property.getType() == Property.Type.BOOLEAN)
+                mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
+                        Type.getType(Boolean.class).getInternalName(),
+                        "booleanValue",
+                        "()Z",
+                        false);
+            else if (property.getType() == Property.Type.NUMBER)
+                mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
+                        Type.getType(Integer.class).getInternalName(),
+                        "intValue",
+                        "()I",
+                        false);
+
+            mv.visitFieldInsn(Opcodes.PUTFIELD,
+                    type(path).getInternalName(),
+                    toCamelCase(property.getName(), false), (
+                            switch (property.getType()) {
+                                case BOOLEAN -> Type.BOOLEAN_TYPE;
+                                case NUMBER -> Type.INT_TYPE;
+                                case OTHER -> type(property.getPath()); }
+                    ).getDescriptor());
+
+            j++;
+        }
+
+        mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(0, 0);
         mv.visitEnd();
         cw.visitEnd();
 
         cw.visitEnd();
         return cw.toByteArray();
-    }
-
-    private Type type(final String dotPath) {
-        return Type.getType("L" + dotPath.replace(".", "/") + ";");
-    }
-
-    private Type array(final Type type) {
-        return Type.getType("[" + type.getDescriptor());
-    }
-
-    private void pushValue(final MethodVisitor mv, final Object o) {
-        int value;
-        if (o instanceof Boolean)
-            value = (Boolean) o ? 1 : 0;
-        else if (o instanceof Character)
-            value = (Character) o;
-        else if (o instanceof Number)
-            value = ((Number) o).intValue();
-        else {
-            mv.visitLdcInsn(o);
-            return;
-        }
-        if (0 <= value && value <= 5)
-            mv.visitInsn(Opcodes.ICONST_0 + value);
-        else if (Byte.MIN_VALUE <= value && value <= Byte.MAX_VALUE)
-            mv.visitIntInsn(Opcodes.BIPUSH, value);
-        else if (Short.MIN_VALUE <= value && value <= Short.MAX_VALUE)
-            mv.visitIntInsn(Opcodes.SIPUSH, value);
-        else
-            mv.visitLdcInsn(value);
     }
 
 }

--- a/code-generators/src/main/java/org/machinemc/generators/blockdata/BlockDataGroup.java
+++ b/code-generators/src/main/java/org/machinemc/generators/blockdata/BlockDataGroup.java
@@ -1,0 +1,199 @@
+/*
+ * This file is part of Machine.
+ *
+ * Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Machine.
+ * If not, see https://www.gnu.org/licenses/.
+ */
+package org.machinemc.generators.blockdata;
+
+import lombok.Getter;
+import org.machinemc.generators.CodeGenerator;
+
+@Getter
+public enum BlockDataGroup {
+
+    BANNER(
+            new String[]{"rotation"},
+            "banner"
+    ),
+    BED(new String[]{"facing", "occupied", "part"}, "bed"),
+    CANDLE(
+            new String[]{"candles", "lit", "waterlogged"},
+            new String[]{"black_candle", "blue_candle", "brown_candle", "candle", "cyan_candle",
+                    "gray_candle", "green_candle", "light_blue_candle", "light_gray_candle",
+                    "lime_candle", "magenta_candle", "orange_candle", "pink_candle",
+                    "purple_candle", "red_candle", "white_candle", "yellow_candle"}
+    ),
+    CANDLE_CAKE(new String[]{"lit"}, "candle_cake"),
+    COMMAND_BLOCK(
+            new String[]{"conditional", "facing"},
+            new String[]{"chain_command_block", "command_block", "repeating_command_block"}
+    ),
+    CORAL_WALL_FAN(
+            new String[]{"facing", "waterlogged"},
+            new String[]{"brain_coral_wall_fan", "bubble_coral_wall_fan", "dead_brain_coral_wall_fan",
+                    "dead_bubble_coral_wall_fan", "dead_fire_coral_wall_fan", "dead_horn_coral_wall_fan",
+                    "dead_tube_coral_wall_fan", "fire_coral_wall_fan",
+                    "horn_coral_wall_fan", "tube_coral_wall_fan"}
+    ),
+    DOOR(
+            new String[]{"facing", "half", "hinge", "open", "powered"},
+            new String[]{"acacia_door", "birch_door", "crimson_door", "dark_oak_door", "iron_door", "jungle_door",
+                    "mangrove_door", "oak_door", "spruce_door", "warped_door"}
+    ),
+    FENCE(
+            new String[]{"east", "north", "south", "waterlogged", "west"},
+            new String[]{"acacia_fence", "birch_fence", "crimson_fence",
+                    "dark_oak_fence", "jungle_fence", "mangrove_fence",
+                    "nether_brick_fence", "oak_fence", "spruce_fence", "warped_fence"}
+    ),
+    FENCE_GATE(
+            new String[]{"facing", "in_wall", "open", "powered"},
+            new String[]{"acacia_fence_gate", "birch_fence_gate",
+                    "crimson_fence_gate", "dark_oak_fence_gate",
+                    "jungle_fence_gate", "mangrove_fence_gate", "oak_fence_gate",
+                    "spruce_fence_gate", "warped_fence_gate"}
+    ),
+    GLASS_PANE(
+            new String[]{"east", "north", "south", "waterlogged", "west"},
+            new String[]{"black_stained_glass_pane", "blue_stained_glass_pane", "brown_stained_glass_pane",
+                    "cyan_stained_glass_pane", "glass_pane", "gray_stained_glass_pane", "green_stained_glass_pane",
+                    "light_blue_stained_glass_pane", "light_gray_stained_glass_pane", "lime_stained_glass_pane",
+                    "magenta_stained_glass_pane", "orange_stained_glass_pane", "pink_stained_glass_pane",
+                    "purple_stained_glass_pane", "red_stained_glass_pane", "white_stained_glass_pane",
+                    "yellow_stained_glass_pane"}
+    ),
+    LEAVES(
+            new String[]{"distance", "persistent", "waterlogged"},
+            new String[]{"acacia_leaves", "azalea_leaves", "birch_leaves", "dark_oak_leaves", "flowering_azalea_leaves",
+                    "jungle_leaves", "mangrove_leaves", "oak_leaves", "spruce_leaves"}
+    ),
+    PISTON(
+            new String[]{"extended", "facing"},
+            new String[]{"piston", "sticky_piston"}
+    ),
+    POTTED(
+            new String[0],
+            new String[]{"potted_acacia_sapling", "potted_allium", "potted_azalea_bush", "potted_azure_bluet",
+                    "potted_bamboo", "potted_birch_sapling", "potted_blue_orchid", "potted_brown_mushroom",
+                    "potted_cactus", "potted_cornflower", "potted_crimson_fungus", "potted_crimson_roots",
+                    "potted_dandelion", "potted_dark_oak_sapling", "potted_dead_bush", "potted_fern",
+                    "potted_flowering_azalea_bush", "potted_jungle_sapling", "potted_lily_of_the_valley",
+                    "potted_mangrove_propagule", "potted_oak_sapling", "potted_orange_tulip", "potted_oxeye_daisy",
+                    "potted_pink_tulip", "potted_poppy", "potted_red_mushroom", "potted_red_tulip",
+                    "potted_spruce_sapling", "potted_warped_fungus", "potted_warped_roots",
+                    "potted_white_tulip", "potted_wither_rose"}
+    ),
+    RAIL(
+            new String[]{"shape", "waterlogged"},
+            new String[]{"activator_rail", "detector_rail", "powered_rail", "rail"}
+    ),
+    REDSTONE_RAIL(
+            new String[]{"powered", "shape", "waterlogged"},
+            new String[]{"activator_rail", "detector_rail", "powered_rail"}
+    ),
+    SAPLING(
+            new String[]{"stage"},
+            new String[]{"acacia_sapling", "birch_sapling", "dark_oak_sapling", "jungle_sapling",
+                    "oak_sapling", "spruce_sapling"}
+    ),
+    SLAB(
+            new String[]{"type", "waterlogged"},
+            new String[]{"acacia_slab", "andesite_slab", "birch_slab", "blackstone_slab",
+                    "brick_slab", "cobbled_deepslate_slab", "cobblestone_slab", "crimson_slab",
+                    "cut_copper_slab", "cut_red_sandstone_slab", "cut_sandstone_slab",
+                    "dark_oak_slab", "dark_prismarine_slab", "deepslate_brick_slab",
+                    "deepslate_tile_slab", "diorite_slab", "end_stone_brick_slab",
+                    "exposed_cut_copper_slab", "granite_slab", "jungle_slab", "mangrove_slab",
+                    "mossy_cobblestone_slab", "mossy_stone_brick_slab", "mud_brick_slab",
+                    "nether_brick_slab", "oak_slab", "oxidized_cut_copper_slab", "petrified_oak_slab",
+                    "polished_andesite_slab", "polished_blackstone_brick_slab", "polished_blackstone_slab",
+                    "polished_deepslate_slab", "polished_diorite_slab", "polished_granite_slab",
+                    "prismarine_brick_slab", "prismarine_slab", "purpur_slab", "quartz_slab",
+                    "red_nether_brick_slab", "red_sandstone_slab", "sandstone_slab", "smooth_quartz_slab",
+                    "smooth_red_sandstone_slab", "smooth_sandstone_slab", "smooth_stone_slab",
+                    "spruce_slab", "stone_brick_slab", "stone_slab", "warped_slab", "waxed_cut_copper_slab",
+                    "waxed_exposed_cut_copper_slab", "waxed_oxidized_cut_copper_slab",
+                    "waxed_weathered_cut_copper_slab", "weathered_cut_copper_slab"}
+    ),
+    SIGN(
+            new String[]{"rotation", "waterlogged"},
+            new String[]{"acacia_sign", "birch_sign", "crimson_sign", "dark_oak_sign", "jungle_sign",
+                    "mangrove_sign", "oak_sign", "spruce_sign", "warped_sign"}
+    ),
+    TRAP_DOOR(
+            new String[]{"facing", "half", "open", "powered", "waterlogged"},
+            new String[]{"acacia_trapdoor", "birch_trapdoor", "crimson_trapdoor", "dark_oak_trapdoor", "iron_trapdoor",
+                    "jungle_trapdoor", "mangrove_trapdoor", "oak_trapdoor", "spruce_trapdoor", "warped_trapdoor"}
+    ),
+    STAIRS(
+            new String[]{"facing", "half", "shape", "waterlogged"},
+            new String[]{"acacia_stairs", "andesite_stairs", "birch_stairs", "blackstone_stairs", "brick_stairs",
+                    "cobbled_deepslate_stairs", "cobblestone_stairs", "crimson_stairs", "cut_copper_stairs",
+                    "dark_oak_stairs", "dark_prismarine_stairs", "deepslate_brick_stairs", "deepslate_tile_stairs",
+                    "diorite_stairs", "end_stone_brick_stairs", "exposed_cut_copper_stairs", "granite_stairs",
+                    "jungle_stairs", "mangrove_stairs", "mossy_cobblestone_stairs", "mossy_stone_brick_stairs",
+                    "mud_brick_stairs", "nether_brick_stairs", "oak_stairs", "oxidized_cut_copper_stairs",
+                    "polished_andesite_stairs", "polished_blackstone_brick_stairs", "polished_blackstone_stairs",
+                    "polished_deepslate_stairs", "polished_diorite_stairs", "polished_granite_stairs",
+                    "prismarine_brick_stairs", "prismarine_stairs", "purpur_stairs", "quartz_stairs",
+                    "red_nether_brick_stairs", "red_sandstone_stairs", "sandstone_stairs", "smooth_quartz_stairs",
+                    "smooth_red_sandstone_stairs", "smooth_sandstone_stairs", "spruce_stairs", "stone_brick_stairs",
+                    "stone_stairs", "warped_stairs", "waxed_cut_copper_stairs", "waxed_exposed_cut_copper_stairs",
+                    "waxed_oxidized_cut_copper_stairs", "waxed_weathered_cut_copper_stairs",
+                    "weathered_cut_copper_stairs"}
+    ),
+    WALL(
+            new String[]{"east", "north", "south", "up", "waterlogged", "west"},
+            new String[]{"andesite_wall", "blackstone_wall", "brick_wall", "cobbled_deepslate_wall",
+                    "cobblestone_wall", "deepslate_brick_wall", "deepslate_tile_wall", "diorite_wall",
+                    "end_stone_brick_wall", "granite_wall", "mossy_cobblestone_wall", "mossy_stone_brick_wall",
+                    "mud_brick_wall", "nether_brick_wall", "polished_blackstone_brick_wall",
+                    "polished_blackstone_wall", "polished_deepslate_wall", "prismarine_wall",
+                    "red_nether_brick_wall", "red_sandstone_wall", "sandstone_wall", "stone_brick_wall"}
+    ),
+    WALL_BANNER(new String[]{"facing"}, "wall_banner"),
+    WALL_SIGN(
+            new String[]{"facing", "waterlogged"},
+            new String[]{"acacia_wall_sign", "birch_wall_sign", "crimson_wall_sign", "dark_oak_wall_sign",
+                    "jungle_wall_sign", "mangrove_wall_sign", "oak_wall_sign", "spruce_wall_sign",
+                    "warped_wall_sign"}
+    );
+
+    private final String[] properties;
+    private final String[] blocks;
+
+    BlockDataGroup(final String[] properties, final String[] blocks) {
+        this.properties = properties;
+        this.blocks = new String[blocks.length];
+        for (int i = 0; i < blocks.length; i++)
+            this.blocks[i] = "minecraft:" + blocks[i];
+    }
+
+    BlockDataGroup(final String[] properties, final String baseName) {
+        final String[] colors = {"black", "blue", "brown", "cyan", "gray",
+                "green", "light_blue", "light_gray", "lime", "magenta", "orange", "pink", "purple",
+                "red", "white", "yellow"};
+        this.properties = properties;
+        blocks = new String[16];
+        for (int i = 0; i < blocks.length; i++) {
+            blocks[i] = "minecraft:" + colors[i] + "_" + baseName;
+        }
+    }
+
+    /**
+     * @return path of the interface for this group
+     */
+    public String getPath() {
+        return "org.machinemc.api.world.blockdata." + CodeGenerator.toCamelCase(name(), true) + "DataGroup";
+    }
+
+}

--- a/code-generators/src/main/java/org/machinemc/generators/blockdata/BlockDataLibGenerator.java
+++ b/code-generators/src/main/java/org/machinemc/generators/blockdata/BlockDataLibGenerator.java
@@ -32,7 +32,7 @@ public class BlockDataLibGenerator extends CodeGenerator {
     @Getter(AccessLevel.PROTECTED)
     private final Map<String, Property> properties = new LinkedHashMap<>();
 
-    public BlockDataLibGenerator(final File outputDir) throws IOException {
+    public BlockDataLibGenerator(final File outputDir) {
         super(outputDir, "blockdata", "blocks.json");
     }
 
@@ -58,7 +58,7 @@ public class BlockDataLibGenerator extends CodeGenerator {
         cw.visitEnd();
         addClass("org.machinemc.api.world.blockdata.BlockDataProperty", cw.toByteArray());
 
-        final JsonObject json = getSource().getAsJsonObject();
+        final JsonObject json = getJson().getAsJsonObject();
         for (final Map.Entry<String, JsonElement> entry : json.entrySet()) {
             if (entry.getValue().getAsJsonObject().get("properties") == null) continue;
             final JsonObject properties = entry.getValue().getAsJsonObject().get("properties").getAsJsonObject();

--- a/code-generators/src/main/java/org/machinemc/generators/blockdata/BlockDataLibGenerator.java
+++ b/code-generators/src/main/java/org/machinemc/generators/blockdata/BlockDataLibGenerator.java
@@ -22,7 +22,6 @@ import org.machinemc.generators.CodeGenerator;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,7 +50,7 @@ public class BlockDataLibGenerator extends CodeGenerator {
         CodeGenerator.visitGeneratedAnnotation(cw, BlockDataLibGenerator.class);
         final MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT,
                 "getName",
-                "()" + Type.getType(String.class).getDescriptor(),
+                "()Ljava/lang/String;",
                 null,
                 new String[0]);
         mv.visitEnd();

--- a/code-generators/src/main/java/org/machinemc/generators/blockdata/Property.java
+++ b/code-generators/src/main/java/org/machinemc/generators/blockdata/Property.java
@@ -64,7 +64,7 @@ public class Property {
      * @return enum class data of this property
      */
     public byte[] generate() {
-        final ClassWriter cw = new ClassWriter(Opcodes.ASM9 | ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+        final ClassWriter cw = createWriter();
         cw.visit(Opcodes.V17,
                 Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_SUPER | Opcodes.ACC_ENUM,
                 type(path).getInternalName(),

--- a/code-generators/src/main/java/org/machinemc/generators/blockdata/Property.java
+++ b/code-generators/src/main/java/org/machinemc/generators/blockdata/Property.java
@@ -147,7 +147,7 @@ public class Property {
         // getName method
         mv = cw.visitMethod(Opcodes.ACC_PUBLIC,
                 "getName",
-                "()" + org.objectweb.asm.Type.getType(String.class).getDescriptor(),
+                "()Ljava/lang/String;",
                 null,
                 new String[0]);
         mv.visitAnnotation(org.objectweb.asm.Type.getType(Override.class).getDescriptor(), true).visitEnd();

--- a/code-generators/src/main/java/org/machinemc/generators/blockdata/Property.java
+++ b/code-generators/src/main/java/org/machinemc/generators/blockdata/Property.java
@@ -15,20 +15,20 @@
 package org.machinemc.generators.blockdata;
 
 import lombok.Getter;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.FieldVisitor;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
+import org.machinemc.generators.CodeGenerator;
+import org.objectweb.asm.*;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import static org.machinemc.generators.blockdata.BlockDataLibGenerator.toCamelCase;
+import static org.machinemc.generators.CodeGenerator.*;
 
 public class Property {
 
     @Getter
     private final String name;
+    @Getter
+    private final String formattedName;
     @Getter
     private final String path;
     @Getter
@@ -37,7 +37,8 @@ public class Property {
 
     public Property(final String name) {
         this.name = name;
-        path = "org.machinemc.api.world.blockdata." + name + "Property";
+        this.formattedName = toCamelCase(name, true);
+        path = "org.machinemc.api.world.blockdata." + formattedName + "Property";
     }
 
     /**
@@ -69,7 +70,8 @@ public class Property {
                 type(path).getInternalName(),
                 null,
                 org.objectweb.asm.Type.getInternalName(Enum.class),
-                new String[0]);
+                new String[]{type("org.machinemc.api.world.blockdata.BlockDataProperty").getInternalName()});
+        CodeGenerator.visitGeneratedAnnotation(cw, BlockDataLibGenerator.class);
 
         // Fields
         for (final String value : values) {
@@ -138,6 +140,21 @@ public class Property {
                 "$VALUES",
                 array(type(path)).getDescriptor());
         mv.visitInsn(Opcodes.RETURN);
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+        cw.visitEnd();
+
+        // getName method
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC,
+                "getName",
+                "()" + org.objectweb.asm.Type.getType(String.class).getDescriptor(),
+                null,
+                new String[0]);
+        mv.visitAnnotation(org.objectweb.asm.Type.getType(Override.class).getDescriptor(), true).visitEnd();
+        mv.visitEnd();
+        mv.visitCode();
+        pushValue(mv, name);
+        mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(0, 0);
         mv.visitEnd();
         cw.visitEnd();
@@ -230,7 +247,7 @@ public class Property {
      * @return data for interface of this property
      */
     public byte[] generateInterface() {
-        final String interfacePath = "org.machinemc.api.world.blockdata.interfaces.Has" + name;
+        final String interfacePath = "org.machinemc.api.world.blockdata.interfaces.Has" + formattedName;
         final String descriptor = switch (getType()) {
             case BOOLEAN -> org.objectweb.asm.Type.BOOLEAN_TYPE.getDescriptor();
             case NUMBER -> org.objectweb.asm.Type.INT_TYPE.getDescriptor();
@@ -243,14 +260,15 @@ public class Property {
                 null,
                 org.objectweb.asm.Type.getInternalName(Object.class),
                 new String[0]);
+        CodeGenerator.visitGeneratedAnnotation(cw, BlockDataLibGenerator.class);
         MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT,
-                "get" + toCamelCase(name, true),
+                "get" + formattedName,
                 "()" + descriptor,
                 null,
                 new String[0]);
         mv.visitEnd();
         mv = cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT,
-                "set" + toCamelCase(name, true),
+                "set" + formattedName,
                 "(" + descriptor + ")V",
                 null,
                 new String[0]);
@@ -263,7 +281,7 @@ public class Property {
      * @return dot path of the interface for this property
      */
     public String getInterfacePath() {
-        return "org.machinemc.api.world.blockdata.interfaces.Has" + name;
+        return "org.machinemc.api.world.blockdata.interfaces.Has" + formattedName;
     }
 
     /**
@@ -294,36 +312,6 @@ public class Property {
         }
         type = Type.NUMBER;
         return Type.NUMBER;
-    }
-
-    private org.objectweb.asm.Type type(final String dotPath) {
-        return org.objectweb.asm.Type.getType("L" + dotPath.replace(".", "/") + ";");
-    }
-
-    private org.objectweb.asm.Type array(final org.objectweb.asm.Type type) {
-        return org.objectweb.asm.Type.getType("[" + type.getDescriptor());
-    }
-
-    private void pushValue(final MethodVisitor mv, final Object o) {
-        int value;
-        if (o instanceof Boolean)
-            value = (Boolean) o ? 1 : 0;
-        else if (o instanceof Character)
-            value = (Character) o;
-        else if (o instanceof Number)
-            value = ((Number) o).intValue();
-        else {
-            mv.visitLdcInsn(o);
-            return;
-        }
-        if (0 <= value && value <= 5)
-            mv.visitInsn(Opcodes.ICONST_0 + value);
-        else if (Byte.MIN_VALUE <= value && value <= Byte.MAX_VALUE)
-            mv.visitIntInsn(Opcodes.BIPUSH, value);
-        else if (Short.MIN_VALUE <= value && value <= Short.MAX_VALUE)
-            mv.visitIntInsn(Opcodes.SIPUSH, value);
-        else
-            mv.visitLdcInsn(value);
     }
 
     public enum Type {

--- a/code-generators/src/main/java/org/machinemc/generators/materials/MaterialsLibGenerator.java
+++ b/code-generators/src/main/java/org/machinemc/generators/materials/MaterialsLibGenerator.java
@@ -70,6 +70,8 @@ public class MaterialsLibGenerator extends CodeGenerator {
                 Type.getInternalName(Enum.class),
                 new String[0]);
 
+        CodeGenerator.visitGeneratedAnnotation(cw, MaterialsLibGenerator.class);
+
         // Fields
         for (final String value : itemsMap.keySet()) {
             final FieldVisitor fv = cw.visitField(Opcodes.ACC_PUBLIC

--- a/code-generators/src/main/java/org/machinemc/generators/materials/MaterialsLibGenerator.java
+++ b/code-generators/src/main/java/org/machinemc/generators/materials/MaterialsLibGenerator.java
@@ -35,16 +35,16 @@ public class MaterialsLibGenerator extends CodeGenerator {
     @Getter
     private final String path = MATERIAL_CLASS;
 
-    public MaterialsLibGenerator(final File outputDir) throws IOException {
+    public MaterialsLibGenerator(final File outputDir) {
         super(outputDir, "materials", "registries.json");
     }
 
     @Override
     public void generate() throws IOException {
         System.out.println("Generating the " + super.getLibraryName() + " library");
-        setSource(getSource().get("minecraft:item").getAsJsonObject()
+        setJson(getJson().get("minecraft:item").getAsJsonObject()
                 .get("entries").getAsJsonObject());
-        for (final Map.Entry<String, JsonElement> entry : getSource().entrySet())
+        for (final Map.Entry<String, JsonElement> entry : getJson().entrySet())
             handleEntry(entry, true);
 
         // Getting the BlockData information

--- a/code-generators/src/main/java/org/machinemc/generators/materials/MaterialsLibGenerator.java
+++ b/code-generators/src/main/java/org/machinemc/generators/materials/MaterialsLibGenerator.java
@@ -153,7 +153,11 @@ public class MaterialsLibGenerator extends CodeGenerator {
                 "setMaterial",
                 "(" + type(path).getDescriptor() + ")" + type(iBlockDataPath).getDescriptor(),
                 false);
-        mv.visitInsn(Opcodes.POP);
+        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
+                type(iBlockDataPath).getInternalName(),
+                "register",
+                "()V",
+                false);
         mv.visitJumpInsn(Opcodes.GOTO, end);
 
         mv.visitLabel(end);

--- a/code-generators/src/main/java/org/machinemc/generators/materials/MaterialsLibGenerator.java
+++ b/code-generators/src/main/java/org/machinemc/generators/materials/MaterialsLibGenerator.java
@@ -35,16 +35,16 @@ public class MaterialsLibGenerator extends CodeGenerator {
     @Getter
     private final String path = MATERIAL_CLASS;
 
-    public MaterialsLibGenerator(final File outputDir) throws IOException {
+    public MaterialsLibGenerator(final File outputDir) {
         super(outputDir, "materials", "registries.json");
     }
 
     @Override
     public void generate() throws IOException {
         System.out.println("Generating the " + super.getLibraryName() + " library");
-        setSource(getSource().get("minecraft:item").getAsJsonObject()
+        setJson(getJson().get("minecraft:item").getAsJsonObject()
                 .get("entries").getAsJsonObject());
-        for (final Map.Entry<String, JsonElement> entry : getSource().entrySet())
+        for (final Map.Entry<String, JsonElement> entry : getJson().entrySet())
             handleEntry(entry, true);
 
         // Getting the BlockData information
@@ -69,6 +69,8 @@ public class MaterialsLibGenerator extends CodeGenerator {
                 null,
                 Type.getInternalName(Enum.class),
                 new String[0]);
+
+        CodeGenerator.visitGeneratedAnnotation(cw, MaterialsLibGenerator.class);
 
         // Fields
         for (final String value : itemsMap.keySet()) {
@@ -151,7 +153,11 @@ public class MaterialsLibGenerator extends CodeGenerator {
                 "setMaterial",
                 "(" + type(path).getDescriptor() + ")" + type(iBlockDataPath).getDescriptor(),
                 false);
-        mv.visitInsn(Opcodes.POP);
+        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
+                type(iBlockDataPath).getInternalName(),
+                "register",
+                "()V",
+                false);
         mv.visitJumpInsn(Opcodes.GOTO, end);
 
         mv.visitLabel(end);

--- a/code-generators/src/main/kotlin/machine.generator-library.gradle.kts
+++ b/code-generators/src/main/kotlin/machine.generator-library.gradle.kts
@@ -1,3 +1,18 @@
 import org.machinemc.generators.LibraryGeneratorPlugin
 
+plugins {
+    `java-library`
+}
+
 apply<LibraryGeneratorPlugin>()
+
+dependencies {
+
+    sequenceOf(
+            "machine-materials",
+            "machine-blockdata",
+    ).forEach {
+        implementation(files("libs/$it.jar"))
+    }
+
+}

--- a/code-generators/src/main/resources/versions.json
+++ b/code-generators/src/main/resources/versions.json
@@ -1,0 +1,4 @@
+{
+  "blockdata": "1.0",
+  "materials": "1.0"
+}

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -20,13 +20,6 @@ dependencies {
 
     implementation(project(":api"))
 
-    sequenceOf(
-        "machine-materials",
-        "machine-blockdata",
-    ).forEach {
-        implementation(files("libs/$it.jar"))
-    }
-
     implementation(libs.google.guava)
     implementation(libs.google.gson)
     implementation(libs.netty.all)

--- a/server/src/main/java/org/machinemc/server/Machine.java
+++ b/server/src/main/java/org/machinemc/server/Machine.java
@@ -20,7 +20,7 @@ import com.google.gson.JsonObject;
 import com.mojang.brigadier.CommandDispatcher;
 import lombok.Getter;
 import org.machinemc.api.auth.OnlineServer;
-import org.machinemc.api.world.Material;
+import org.machinemc.api.world.*;
 import org.machinemc.scriptive.components.TranslationComponent;
 import org.machinemc.scriptive.serialization.ComponentSerializer;
 import org.machinemc.scriptive.serialization.ComponentSerializerImpl;
@@ -50,9 +50,6 @@ import org.machinemc.server.network.packets.PacketFactory;
 import org.machinemc.server.server.PlayerManagerImpl;
 import org.machinemc.api.server.schedule.Scheduler;
 import org.machinemc.server.world.*;
-import org.machinemc.api.world.BlockDataImpl;
-import org.machinemc.api.world.World;
-import org.machinemc.api.world.WorldManager;
 import org.machinemc.api.world.biomes.BiomeManager;
 import org.machinemc.server.world.biomes.BiomeManagerImpl;
 import org.machinemc.api.world.blocks.BlockManager;
@@ -222,7 +219,7 @@ public final class Machine implements Server {
         ServerCommands.register(this, commandDispatcher);
 
         Arrays.stream(Material.values()).forEach(Material::createBlockData);
-        BlockDataImpl.finishRegistration();
+        BlockData.finishRegistration();
         blockManager = BlockManagerImpl.createDefault(this);
         console.info("Loaded materials and block data");
 

--- a/server/src/main/java/org/machinemc/server/world/particles/options/BlockOptionsImpl.java
+++ b/server/src/main/java/org/machinemc/server/world/particles/options/BlockOptionsImpl.java
@@ -21,7 +21,6 @@ import org.machinemc.nbt.NBTCompound;
 import org.machinemc.server.utils.FriendlyByteBuf;
 import org.machinemc.api.utils.ServerBuffer;
 import org.machinemc.api.world.BlockData;
-import org.machinemc.api.world.BlockDataImpl;
 import org.machinemc.server.world.particles.ParticleFactory;
 import org.machinemc.api.world.particles.options.BlockOptions;
 
@@ -47,7 +46,7 @@ public class BlockOptionsImpl implements BlockOptions {
     }
 
     public BlockOptionsImpl(final ServerBuffer buf) {
-        final BlockData blockData = BlockDataImpl.getBlockData(buf.readVarInt());
+        final BlockData blockData = BlockData.getBlockData(buf.readVarInt());
         this.blockData = blockData != null ? blockData : DEFAULT_LOOK.createBlockData();
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR reworks the old code generators plugin, making its generated libraries better and its code easier to understand. 

**What is the current behavior?** (You can also link to an open issue here)
Block state ids are stored in a huge map, making the system memory inefficient since most of the ids can be calculated during runtime. For updating the libraries user needs to delete the generated jars and regenerate them. There are some inconsistencies in the code generator plugin code. Generated classes are not annotated with Generated annotation.

**What is the new behavior?** (If this is a feature change)
There are now automatic version checks for updating the generated libraries, which are now much more optimized and store about 40x less data since most block state ids are now calculated during runtime. The whole system also offers better security and flexibility, for example allowing users to get a map of block data keys and values used, allowing stuff like displaying block crack particles. Similar block data groups like beds or signs now have their own interface for easier manipulation.

**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
None

* [x] I follow Machine contributing guidelines