### PR TITLE
Player Movement

### DIFF
--- a/api/src/main/java/org/machinemc/api/entities/Entity.java
+++ b/api/src/main/java/org/machinemc/api/entities/Entity.java
@@ -121,7 +121,7 @@ public interface Entity extends ServerProperty, NBTSerializable, Nameable {
     void setTicksFrozen(int ticksFrozen);
 
     /**
-     * @return location of the entity
+     * @return clone of the location of the entity
      */
     Location getLocation();
 
@@ -129,6 +129,11 @@ public interface Entity extends ServerProperty, NBTSerializable, Nameable {
      * @param location new location
      */
     void setLocation(Location location);
+
+    /**
+     * @return previous location of the entity
+     */
+    Location getPreviousLocation();
 
     /**
      * @return fall distance of the entity

--- a/api/src/main/java/org/machinemc/api/entities/Entity.java
+++ b/api/src/main/java/org/machinemc/api/entities/Entity.java
@@ -126,11 +126,6 @@ public interface Entity extends ServerProperty, NBTSerializable, Nameable {
     Location getLocation();
 
     /**
-     * @param location new location
-     */
-    void setLocation(Location location);
-
-    /**
      * @return previous location of the entity
      */
     Location getPreviousLocation();

--- a/api/src/main/java/org/machinemc/api/entities/Entity.java
+++ b/api/src/main/java/org/machinemc/api/entities/Entity.java
@@ -156,11 +156,6 @@ public interface Entity extends ServerProperty, NBTSerializable, Nameable {
     boolean isOnGround();
 
     /**
-     * @param onGround new on ground
-     */
-    void setOnGround(boolean onGround);
-
-    /**
      * @return if the entity is invulnerable
      */
     boolean isInvulnerable();

--- a/api/src/main/java/org/machinemc/api/network/PlayerConnection.java
+++ b/api/src/main/java/org/machinemc/api/network/PlayerConnection.java
@@ -34,6 +34,7 @@ import static org.machinemc.api.network.packets.Packet.PacketState.*;
 /**
  * Represents a connection of a client.
  */
+@ApiStatus.NonExtendable
 public interface PlayerConnection extends ServerProperty {
 
     /**

--- a/api/src/main/java/org/machinemc/api/network/ServerConnection.java
+++ b/api/src/main/java/org/machinemc/api/network/ServerConnection.java
@@ -20,10 +20,12 @@ import org.machinemc.api.server.ServerProperty;
 import org.jetbrains.annotations.*;
 
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Represents server's connection.
  */
+@ApiStatus.NonExtendable
 public interface ServerConnection extends ServerProperty {
 
     /**
@@ -58,6 +60,13 @@ public interface ServerConnection extends ServerProperty {
      * @param packet packet to send
      */
     void broadcastPacket(Packet packet);
+
+    /**
+     * Sends a packet to all clients matching the predicate.
+     * @param packet packet to send
+     * @param predicate predicate
+     */
+    void broadcastPacket(Packet packet, Predicate<PlayerConnection> predicate);
 
     /**
      * Disconnects a player connection from the server.

--- a/api/src/main/java/org/machinemc/api/world/EntityPosition.java
+++ b/api/src/main/java/org/machinemc/api/world/EntityPosition.java
@@ -1,0 +1,295 @@
+/*
+ * This file is part of Machine.
+ *
+ * Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Machine.
+ * If not, see https://www.gnu.org/licenses/.
+ */
+package org.machinemc.api.world;
+
+import lombok.Data;
+import lombok.With;
+import org.jetbrains.annotations.Contract;
+import org.machinemc.api.utils.ServerBuffer;
+import org.machinemc.api.utils.Writable;
+import org.machinemc.api.utils.math.Vector2;
+import org.machinemc.api.utils.math.Vector3;
+
+/**
+ * Represent a position of an entity.
+ */
+@Data
+@With
+public sealed class EntityPosition implements Cloneable, Writable permits Location {
+
+    private double x, y, z;
+    private float yaw, pitch;
+
+    /**
+     * Creates new position.
+     * @param x x-coordinate of the position
+     * @param y y-coordinate of the position
+     * @param z z-coordinate of the position
+     * @param yaw yaw of the position
+     * @param pitch pitch of the position
+     * @return new position
+     */
+    @Contract("_, _, _, _, _ -> new")
+    public static EntityPosition of(final double x,
+                                    final double y,
+                                    final double z,
+                                    final float yaw,
+                                    final float pitch) {
+        return new EntityPosition(x, y, z, yaw, pitch);
+    }
+
+    /**
+     * Creates new position.
+     * @param x x-coordinate of the position
+     * @param y y-coordinate of the position
+     * @param z z-coordinate of the position
+     * @return new position
+     */
+    @Contract("_, _, _ -> new")
+    public static EntityPosition of(final double x, final double y, final double z) {
+        return new EntityPosition(x, y, z, 0, 0);
+    }
+
+    /**
+     * Creates new entity position from block position.
+     * @param blockPosition block positioncation
+     * @return new position
+     */
+    @Contract("_ -> new")
+    public static EntityPosition of(final BlockPosition blockPosition) {
+        return new EntityPosition(blockPosition);
+    }
+
+    /**
+     * Creates new position from a server buffer.
+     * @param buf buffer with encoded position
+     * @return entity position
+     */
+    @Contract("_ -> new")
+    public static EntityPosition read(final ServerBuffer buf) {
+        return new EntityPosition(buf.readDouble(), buf.readDouble(), buf.readDouble(),
+                buf.readAngle(), buf.readAngle());
+    }
+
+    /**
+     * Entity Position in a world.
+     * @param x x-coordinate of the position
+     * @param y y-coordinate of the position
+     * @param z z-coordinate of the position
+     * @param yaw yaw of the position
+     * @param pitch pitch of the position
+     */
+    public EntityPosition(final double x, final double y, final double z, final float yaw, final float pitch) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.yaw = fixYaw(yaw);
+        this.pitch = pitch;
+    }
+
+    /**
+     * Entity Position in a world.
+     * @param x x-coordinate of the position
+     * @param y y-coordinate of the position
+     * @param z z-coordinate of the position
+     */
+    public EntityPosition(final double x, final double y, final double z) {
+        this(x, y, z, 0, 0);
+    }
+
+    /**
+     * Position in the world from a block position.
+     * @param blockPosition block position of the entity position
+     */
+    public EntityPosition(final BlockPosition blockPosition) {
+        this(blockPosition.getX(), blockPosition.getY(), blockPosition.getZ());
+    }
+
+    /**
+     * Gets a unit-vector pointing in the direction that this position is
+     * facing.
+     * @return a vector pointing the direction of this position's {@link #getPitch()}
+     * and {@link #getYaw()}
+     */
+    public Vector3 getDirection() {
+        final Vector3 vector = new Vector3();
+        final double rotX = this.getYaw();
+        final double rotY = this.getPitch();
+
+        vector.setY(-Math.sin(Math.toRadians(rotY)));
+        final double xz = Math.cos(Math.toRadians(rotY));
+
+        vector.setX(-xz * Math.sin(Math.toRadians(rotX)));
+        vector.setZ(xz * Math.cos(Math.toRadians(rotX)));
+        return vector;
+    }
+
+    /**
+     * Sets the {@link #getYaw() yaw} and {@link #getPitch() pitch} to point
+     * in the direction of the vector.
+     * @param vector the direction vector
+     * @return the same position
+     */
+    @Contract("_ -> this")
+    public EntityPosition setDirection(final Vector3 vector) {
+        final double pii = 2 * Math.PI;
+        final double x = vector.getX();
+        final double z = vector.getZ();
+
+        if (x == 0 && z == 0) {
+            pitch = vector.getY() > 0 ? -90 : 90;
+            return this;
+        }
+
+        final double theta = Math.atan2(-x, z);
+        yaw = (float) Math.toDegrees((theta + pii) % pii);
+
+        final double x2 = Math.pow(x, 2);
+        final double z2 = Math.pow(z, 2);
+        final double xz = Math.sqrt(x2 + z2);
+        pitch = (float) Math.toDegrees(Math.atan(-vector.getY() / xz));
+
+        return this;
+    }
+
+    /**
+     * Offsets the position by a vector.
+     * @param vector the vector
+     * @return this
+     */
+    @Contract("_ -> this")
+    public EntityPosition offset(final Vector3 vector) {
+        x += vector.getX();
+        y += vector.getY();
+        z += vector.getZ();
+        return this;
+    }
+
+    /**
+     * @return x-coordinate of the position as whole number
+     */
+    public int getBlockX() {
+        return (int) Math.floor(x);
+    }
+
+    /**
+     * @return y-coordinate of the position as whole number
+     */
+    public int getBlockY() {
+        return (int) Math.floor(y);
+    }
+
+    /**
+     * @return z-coordinate of the position as whole number
+     */
+    public int getBlockZ() {
+        return (int) Math.floor(z);
+    }
+
+    /**
+     * Converts the entity position to a block position.
+     * @return block position of this entity position
+     */
+    @Contract(pure = true)
+    public BlockPosition toBlockPosition() {
+        return new BlockPosition(getBlockX(), getBlockY(), getBlockZ());
+    }
+
+    /**
+     * Converts this position to a vector.
+     * @return vector of this position
+     */
+    @Contract(pure = true)
+    public Vector3 toVector() {
+        return Vector3.of(getBlockX(), getBlockY(), getBlockZ());
+    }
+
+    /**
+     * Converts rotation of the position to a vector.
+     * @return vector with yaw and pitch
+     */
+    public Vector2 getRotationVector() {
+        return Vector2.of(getYaw(), getPitch());
+    }
+
+    /**
+     * Updates the rotation to value of given vector.
+     * @param rotation rotation vector
+     */
+    public void setRotation(final Vector2 rotation) {
+        setYaw((float) rotation.getX());
+        setPitch((float) rotation.getY());
+    }
+
+    /**
+     * Writes the coordinates of the position to the buffer.
+     * @param buf buffer to write into
+     */
+    public void writePos(final ServerBuffer buf) {
+        buf.writeDouble(x).writeDouble(y).writeDouble(z);
+    }
+
+    /**
+     * Writes the rotation of the position to the buffer.
+     * @param buf buffer to write into
+     */
+    public void writeRot(final ServerBuffer buf) {
+        buf.writeAngle(yaw).writeAngle(pitch);
+    }
+
+    /**
+     * Writes the position to the buffer.
+     * @param buf buffer to write into
+     */
+    @Override
+    public void write(final ServerBuffer buf) {
+        writePos(buf);
+        writeRot(buf);
+    }
+
+    /**
+     * Fixes the yaw between -180 and 180 degrees.
+     * @param yaw yaw
+     * @return same yaw but between -180 and 180 degrees
+     */
+    private static float fixYaw(final float yaw) {
+        float fixedYaw = yaw % 360;
+        if (fixedYaw < -180.0F) {
+            fixedYaw += 360.0F;
+        } else if (fixedYaw > 180.0F) {
+            fixedYaw -= 360.0F;
+        }
+        return fixedYaw;
+    }
+
+    /**
+     * Checks whether the position is valid or not.
+     * @param position position
+     * @return if the position is valid
+     */
+    public static boolean isInvalid(final EntityPosition position) {
+        final double x = position.getX(), y = position.getY(), z = position.getZ();
+        if (!(Double.isFinite(x) && Double.isFinite(y) && Double.isFinite(z)))
+            return true;
+        return Math.max(Math.abs(x), Math.abs(z)) > 3.2e+7;
+    }
+
+    @Override
+    @SuppressWarnings("MethodDoesntCallSuperMethod")
+    public EntityPosition clone() {
+        return new EntityPosition(x, y, z, yaw, pitch);
+    }
+
+}

--- a/api/src/main/java/org/machinemc/api/world/Location.java
+++ b/api/src/main/java/org/machinemc/api/world/Location.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.Contract;
 /**
  * Represents the location in the world.
  */
-@ToString
 @EqualsAndHashCode(callSuper = true)
 public final class Location extends EntityPosition implements Cloneable, Writable {
 
@@ -159,6 +158,19 @@ public final class Location extends EntityPosition implements Cloneable, Writabl
     @Override
     public Location clone() {
         return new Location(getX(), getY(), getZ(), getYaw(), getPitch(), world);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("Location(");
+        sb.append("x=").append(getX()).append(", ");
+        sb.append("y=").append(getY()).append(", ");
+        sb.append("z=").append(getZ()).append(", ");
+        sb.append("yaw=").append(getYaw()).append(", ");
+        sb.append("pitch=").append(getPitch()).append(", ");
+        sb.append("world=").append(world);
+        sb.append(')');
+        return sb.toString();
     }
 
 }

--- a/api/src/main/java/org/machinemc/api/world/World.java
+++ b/api/src/main/java/org/machinemc/api/world/World.java
@@ -16,7 +16,6 @@ package org.machinemc.api.world;
 
 import org.machinemc.api.chunk.Chunk;
 import org.machinemc.api.entities.Entity;
-import org.machinemc.api.entities.Player;
 import org.machinemc.api.server.ServerProperty;
 import org.machinemc.api.utils.NamespacedKey;
 import org.machinemc.api.world.biomes.Biome;
@@ -122,24 +121,11 @@ public interface World extends ServerProperty {
     void save() throws IOException;
 
     /**
-     * Loads player into the world.
-     * @param player player to load
-     */
-    void loadPlayer(Player player);
-
-    /**
-     * Unloads player from the world.
-     * @param player player to unload
-     */
-    void unloadPlayer(Player player);
-
-    /**
      * Spawns an entity to the world at given location.
      * @param entity entity to spawn
-     * @param location location to spawn
      * @return if the operation was successful
      */
-    boolean spawn(Entity entity, Location location);
+    boolean spawn(Entity entity);
 
     /**
      * Removes an entity from the world.

--- a/server/src/main/java/org/machinemc/server/entities/ServerEntity.java
+++ b/server/src/main/java/org/machinemc/server/entities/ServerEntity.java
@@ -124,7 +124,7 @@ public abstract class ServerEntity implements Entity {
 
     @Override
     public World getWorld() {
-        return location.getWorld();
+        return getLocation().getWorld();
     }
 
     @Override
@@ -166,7 +166,7 @@ public abstract class ServerEntity implements Entity {
             throw new IllegalStateException(this + " is already initiated");
         active = true;
         getServer().getEntityManager().addEntity(this);
-        getWorld().spawn(this, location);
+        getWorld().spawn(this);
     }
 
     @Override

--- a/server/src/main/java/org/machinemc/server/entities/ServerEntity.java
+++ b/server/src/main/java/org/machinemc/server/entities/ServerEntity.java
@@ -61,8 +61,9 @@ public abstract class ServerEntity implements Entity {
     private boolean hasVisualFire;
     @Getter @Setter
     private int ticksFrozen;
-    @Getter @Setter
     private Location location;
+    @Getter
+    private Location previousLocation;
     @Getter @Setter
     private float fallDistance;
     @Getter @Setter
@@ -81,6 +82,11 @@ public abstract class ServerEntity implements Entity {
         entityId = EntityUtils.getEmptyID();
         location = new Location(0, 0, 0, getServer().getDefaultWorld());
         active = false;
+    }
+
+    @Override
+    public Location getLocation() {
+        return location.clone();
     }
 
     @Override
@@ -128,6 +134,14 @@ public abstract class ServerEntity implements Entity {
     @Override
     public boolean removeTag(final String tag) {
         return tags.remove(tag);
+    }
+
+    @Override
+    public void setLocation(final Location location) {
+        if (location.getWorld() == null)
+            location.setWorld(getWorld());
+        this.previousLocation = this.location;
+        this.location = location;
     }
 
     @Override

--- a/server/src/main/java/org/machinemc/server/entities/ServerEntity.java
+++ b/server/src/main/java/org/machinemc/server/entities/ServerEntity.java
@@ -16,17 +16,21 @@ package org.machinemc.server.entities;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
+import org.machinemc.api.entities.Entity;
+import org.machinemc.api.entities.EntityType;
+import org.machinemc.api.entities.Player;
+import org.machinemc.api.network.PlayerConnection;
+import org.machinemc.api.utils.NBTUtils;
+import org.machinemc.api.world.EntityPosition;
+import org.machinemc.api.world.Location;
+import org.machinemc.api.world.World;
 import org.machinemc.nbt.NBTCompound;
 import org.machinemc.nbt.NBTList;
 import org.machinemc.scriptive.components.Component;
 import org.machinemc.server.Machine;
-import org.machinemc.api.entities.Entity;
-import org.machinemc.api.entities.EntityType;
+import org.machinemc.server.network.packets.out.play.*;
 import org.machinemc.server.utils.EntityUtils;
-import org.machinemc.api.utils.NBTUtils;
-import org.machinemc.api.world.Location;
-import org.machinemc.api.world.World;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
@@ -136,11 +140,15 @@ public abstract class ServerEntity implements Entity {
         return tags.remove(tag);
     }
 
-    @Override
-    public void setLocation(final Location location) {
+    /**
+     * @param location new location
+     * @param setPreviousLocation whether the previous location should be updated
+     */
+    void setLocation(final Location location, final boolean setPreviousLocation) {
         if (location.getWorld() == null)
             location.setWorld(getWorld());
-        this.previousLocation = this.location;
+        if (setPreviousLocation)
+            this.previousLocation = this.location;
         this.location = location;
     }
 
@@ -158,8 +166,77 @@ public abstract class ServerEntity implements Entity {
         if (!active)
             throw new IllegalStateException(this + " is not active");
         active = false;
+        getServer().getConnection().broadcastPacket(
+                new PacketPlayOutRemoveEntities(new int[]{getEntityId()})
+        );
         getServer().getEntityManager().removeEntity(this);
         getWorld().remove(this);
+    }
+
+    /**
+     * Handles the movement of the entity.
+     * @param position new position
+     * @param onGround if the entity is on ground
+     */
+    public void handleMovement(final EntityPosition position, final boolean onGround) {
+        handleOnGround(onGround);
+
+        final Location currentLocation = getLocation();
+
+        final double deltaX = Math.abs(position.getX() - currentLocation.getX());
+        final double deltaY = Math.abs(position.getY() - currentLocation.getY());
+        final double deltaZ = Math.abs(position.getZ() - currentLocation.getZ());
+        final float deltaYaw = Math.abs(position.getYaw() - currentLocation.getYaw());
+        final float deltaPitch = Math.abs(position.getPitch() - currentLocation.getPitch());
+
+        final boolean positionChange = (deltaX + deltaY + deltaZ) > 0;
+        final boolean rotationChange = (deltaYaw + deltaPitch) > 0;
+        if (!(positionChange || rotationChange))
+            return;
+
+        final PlayerConnection connection;
+        if (this instanceof Player player) {
+            connection = player.getConnection();
+        } else {
+            connection = null;
+        }
+
+        if (positionChange) {
+            if (deltaX > 8 || deltaY > 8 || deltaZ > 8)
+                getServer().getConnection().broadcastPacket(
+                        new PacketPlayOutTeleportEntity(getEntityId(), position, onGround),
+                        clientConnection -> clientConnection != connection);
+            if (rotationChange)
+                getServer().getConnection().broadcastPacket(
+                    new PacketPlayOutEntityPositionAndRotation(getEntityId(), currentLocation, position, onGround),
+                    clientConnection -> clientConnection != connection);
+            else
+                getServer().getConnection().broadcastPacket(
+                        new PacketPlayOutEntityPosition(getEntityId(), currentLocation, position, onGround),
+                        clientConnection -> clientConnection != connection);
+
+        } else {
+            getServer().getConnection().broadcastPacket(
+                    new PacketPlayOutEntityRotation(getEntityId(), position, onGround),
+                    clientConnection -> clientConnection != connection);
+        }
+
+        if (rotationChange) {
+            getServer().getConnection().broadcastPacket(
+                    new PacketPlayOutHeadRotation(getEntityId(), position.getYaw()),
+                    clientConnection -> clientConnection != connection
+            );
+        }
+
+        setLocation(Location.of(position, getWorld()), true);
+    }
+
+    /**
+     * Changes the on ground state of the entity.
+     * @param onGround if the entity is on ground
+     */
+    public void handleOnGround(final boolean onGround) {
+        setOnGround(onGround);
     }
 
     @Override
@@ -211,11 +288,14 @@ public abstract class ServerEntity implements Entity {
         if (rotation.size() != 2)
             rotation = new LinkedList<>(List.of(0f, 0f));
 
-        getLocation().setX(pos.get(0));
-        getLocation().setY(pos.get(1));
-        getLocation().setZ(pos.get(2));
-        getLocation().setYaw(rotation.get(0));
-        getLocation().setPitch(rotation.get(1));
+        final Location location = Location.of(
+                pos.get(0), pos.get(1),
+                pos.get(2),
+                rotation.get(0),
+                rotation.get(1),
+                getWorld()
+        );
+        setLocation(location, false);
 
         setFallDistance(nbtCompound.getValue("FallDistance", 0f));
         setRemainingFireTicks(nbtCompound.getValue("Fire", (short) 0));

--- a/server/src/main/java/org/machinemc/server/entities/ServerPlayer.java
+++ b/server/src/main/java/org/machinemc/server/entities/ServerPlayer.java
@@ -343,7 +343,7 @@ public final class ServerPlayer extends ServerLivingEntity implements Player {
         final float yaw = location.getYaw() - (flags.contains(TeleportFlags.YAW) ? getLocation().getYaw() : 0f);
         final float pitch = location.getPitch() - (flags.contains(TeleportFlags.PITCH) ? getLocation().getPitch() : 0f);
 
-        teleportLocation = new Location(x, y, z, yaw, pitch, null);
+        teleportLocation = new Location(x, y, z, yaw, pitch, getWorld());
         if (++teleportId == Integer.MAX_VALUE)
             teleportId = 0;
 

--- a/server/src/main/java/org/machinemc/server/entities/ServerPlayer.java
+++ b/server/src/main/java/org/machinemc/server/entities/ServerPlayer.java
@@ -243,8 +243,6 @@ public final class ServerPlayer extends ServerLivingEntity implements Player {
 
         // Gamemode
         sendGamemodeChange(gamemode);
-
-        getWorld().loadPlayer(this);
     }
 
     @Override
@@ -252,7 +250,7 @@ public final class ServerPlayer extends ServerLivingEntity implements Player {
         if (connection.getState() != PlayerConnection.ClientState.DISCONNECTED)
             throw new IllegalStateException("You can't remove player from server until the connection is closed");
         super.remove();
-        getWorld().unloadPlayer(this);
+        getWorld().remove(this);
         getServer().getConnection().broadcastPacket(
                 new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.Action.REMOVE_PLAYER, this)
         );

--- a/server/src/main/java/org/machinemc/server/file/WorldJson.java
+++ b/server/src/main/java/org/machinemc/server/file/WorldJson.java
@@ -127,6 +127,7 @@ public class WorldJson implements ServerFile, ServerProperty {
      */
     public World buildWorld() {
         final AbstractWorld world = new ServerWorld(folder, server, name, dimensionType, worldType, seed);
+        // TODO should get calculated/from json
         world.setWorldSpawn(new Location(0, dimensionType.getMinY(), 0, world));
         world.setDifficulty(server.getProperties().getDefaultDifficulty());
         return world;

--- a/server/src/main/java/org/machinemc/server/network/ClientConnection.java
+++ b/server/src/main/java/org/machinemc/server/network/ClientConnection.java
@@ -78,7 +78,13 @@ public class ClientConnection implements PlayerConnection {
         this.address = (InetSocketAddress) channel.remoteAddress();
         server = nettyServer.getServer();
         setState(ClientState.HANDSHAKE);
-        channel.closeFuture().addListener(future -> handleClose());
+        channel.closeFuture().addListener(future -> {
+            try {
+                handleClose();
+            } catch (Throwable throwable) {
+                getServerExceptionHandler().handle(throwable);
+            }
+        });
     }
 
     @Override

--- a/server/src/main/java/org/machinemc/server/network/NettyServer.java
+++ b/server/src/main/java/org/machinemc/server/network/NettyServer.java
@@ -32,6 +32,7 @@ import org.machinemc.server.Machine;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
 
 /**
  * Server connection implementation using netty.
@@ -97,6 +98,14 @@ public class NettyServer implements ServerConnection {
     }
 
     @Override
+    public void broadcastPacket(final Packet packet, final Predicate<PlayerConnection> predicate) {
+        getClients().forEach(connection -> {
+            if (predicate.test(connection))
+                connection.send(packet);
+        });
+    }
+
+    @Override
     public ChannelFuture disconnect(final PlayerConnection connection) {
         return connection.disconnect(TranslationComponent.of("disconnect.disconnected"));
     }
@@ -122,7 +131,7 @@ public class NettyServer implements ServerConnection {
                     new CompressionEncoder(connection),
                     new PacketEncoder(connection)
             );
-
+            connections.add(connection);
         }
     }
 

--- a/server/src/main/java/org/machinemc/server/network/PacketDecoder.java
+++ b/server/src/main/java/org/machinemc/server/network/PacketDecoder.java
@@ -45,6 +45,7 @@ public class PacketDecoder extends ByteToMessageDecoder {
         final Packet packet;
         try {
             packet = PacketFactory.produce(PacketFactory.getPacketByRawId(buf.readVarInt(), packetState), buf);
+            buf.finish();
             if (packet == null) return;
         } catch (Throwable throwable) {
             return;

--- a/server/src/main/java/org/machinemc/server/network/packets/in/play/PacketPlayInClientInformation.java
+++ b/server/src/main/java/org/machinemc/server/network/packets/in/play/PacketPlayInClientInformation.java
@@ -28,9 +28,9 @@ import org.machinemc.api.utils.ServerBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
-@AllArgsConstructor
 @ToString
 @Getter @Setter
+@AllArgsConstructor
 public class PacketPlayInClientInformation extends PacketIn {
 
     private static final int ID = 0x08;

--- a/server/src/main/java/org/machinemc/server/network/packets/in/play/PacketPlayInConfirmTeleportation.java
+++ b/server/src/main/java/org/machinemc/server/network/packets/in/play/PacketPlayInConfirmTeleportation.java
@@ -12,43 +12,32 @@
  * You should have received a copy of the GNU General Public License along with Machine.
  * If not, see https://www.gnu.org/licenses/.
  */
-package org.machinemc.server.network.packets.out.play;
+package org.machinemc.server.network.packets.in.play;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.machinemc.api.utils.ServerBuffer;
-import org.machinemc.api.world.EntityPosition;
-import org.machinemc.server.network.packets.PacketOut;
+import org.machinemc.server.network.packets.PacketIn;
 import org.machinemc.server.utils.FriendlyByteBuf;
 
-@AllArgsConstructor
 @ToString
-@Getter @Setter
-public class PacketPlayOutTeleportEntity extends PacketOut {
+@AllArgsConstructor
+public class PacketPlayInConfirmTeleportation extends PacketIn {
 
-    private static final int ID = 0x66;
-
-    private int entityId;
-    private EntityPosition position;
-    private boolean onGround;
+    private static final int ID = 0x00;
 
     static {
-        register(PacketPlayOutTeleportEntity.class, ID, PacketState.PLAY_OUT,
-                PacketPlayOutTeleportEntity::new);
+        register(PacketPlayInConfirmTeleportation.class, ID, PacketState.PLAY_IN,
+                PacketPlayInConfirmTeleportation::new);
     }
 
-    public PacketPlayOutTeleportEntity(final ServerBuffer buf) {
-        entityId = buf.readVarInt();
-        position = EntityPosition.of(
-                buf.readDouble(),
-                buf.readDouble(),
-                buf.readDouble(),
-                buf.readAngle(),
-                buf.readAngle()
-        );
-        onGround = buf.readBoolean();
+    @Getter @Setter
+    private int teleportId;
+
+    public PacketPlayInConfirmTeleportation(final ServerBuffer buf) {
+        teleportId = buf.readVarInt();
     }
 
     @Override
@@ -58,21 +47,19 @@ public class PacketPlayOutTeleportEntity extends PacketOut {
 
     @Override
     public PacketState getPacketState() {
-        return PacketState.PLAY_OUT;
+        return PacketState.PLAY_IN;
     }
 
     @Override
     public byte[] serialize() {
         return new FriendlyByteBuf()
-                .writeVarInt(entityId)
-                .write(position)
-                .writeBoolean(onGround)
+                .writeVarInt(teleportId)
                 .bytes();
     }
 
     @Override
-    public PacketOut clone() {
-        return new PacketPlayOutTeleportEntity(new FriendlyByteBuf(serialize()));
+    public PacketIn clone() {
+        return new PacketPlayInConfirmTeleportation(new FriendlyByteBuf(serialize()));
     }
 
 }

--- a/server/src/main/java/org/machinemc/server/network/packets/in/play/PacketPlayInPlayerOnGround.java
+++ b/server/src/main/java/org/machinemc/server/network/packets/in/play/PacketPlayInPlayerOnGround.java
@@ -12,42 +12,31 @@
  * You should have received a copy of the GNU General Public License along with Machine.
  * If not, see https://www.gnu.org/licenses/.
  */
-package org.machinemc.server.network.packets.out.play;
+package org.machinemc.server.network.packets.in.play;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.machinemc.api.utils.ServerBuffer;
-import org.machinemc.api.world.EntityPosition;
-import org.machinemc.server.network.packets.PacketOut;
+import org.machinemc.server.network.packets.PacketIn;
 import org.machinemc.server.utils.FriendlyByteBuf;
 
-@AllArgsConstructor
 @ToString
 @Getter @Setter
-public class PacketPlayOutTeleportEntity extends PacketOut {
+@AllArgsConstructor
+public class PacketPlayInPlayerOnGround extends PacketIn {
 
-    private static final int ID = 0x66;
-
-    private int entityId;
-    private EntityPosition position;
-    private boolean onGround;
+    private static final int ID = 0x17;
 
     static {
-        register(PacketPlayOutTeleportEntity.class, ID, PacketState.PLAY_OUT,
-                PacketPlayOutTeleportEntity::new);
+        register(PacketPlayInPlayerOnGround.class, ID, PacketState.PLAY_IN,
+                PacketPlayInPlayerOnGround::new);
     }
 
-    public PacketPlayOutTeleportEntity(final ServerBuffer buf) {
-        entityId = buf.readVarInt();
-        position = EntityPosition.of(
-                buf.readDouble(),
-                buf.readDouble(),
-                buf.readDouble(),
-                buf.readAngle(),
-                buf.readAngle()
-        );
+    private boolean onGround;
+
+    public PacketPlayInPlayerOnGround(final ServerBuffer buf) {
         onGround = buf.readBoolean();
     }
 
@@ -58,21 +47,19 @@ public class PacketPlayOutTeleportEntity extends PacketOut {
 
     @Override
     public PacketState getPacketState() {
-        return PacketState.PLAY_OUT;
+        return PacketState.PLAY_IN;
     }
 
     @Override
     public byte[] serialize() {
         return new FriendlyByteBuf()
-                .writeVarInt(entityId)
-                .write(position)
                 .writeBoolean(onGround)
                 .bytes();
     }
 
     @Override
-    public PacketOut clone() {
-        return new PacketPlayOutTeleportEntity(new FriendlyByteBuf(serialize()));
+    public PacketIn clone() {
+        return new PacketPlayInPlayerOnGround(new FriendlyByteBuf(serialize()));
     }
 
 }

--- a/server/src/main/java/org/machinemc/server/network/packets/in/play/PacketPlayInPlayerPosition.java
+++ b/server/src/main/java/org/machinemc/server/network/packets/in/play/PacketPlayInPlayerPosition.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License along with Machine.
  * If not, see https://www.gnu.org/licenses/.
  */
-package org.machinemc.server.network.packets.out.play;
+package org.machinemc.server.network.packets.in.play;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,34 +20,26 @@ import lombok.Setter;
 import lombok.ToString;
 import org.machinemc.api.utils.ServerBuffer;
 import org.machinemc.api.world.EntityPosition;
-import org.machinemc.server.network.packets.PacketOut;
+import org.machinemc.server.network.packets.PacketIn;
 import org.machinemc.server.utils.FriendlyByteBuf;
 
-@AllArgsConstructor
 @ToString
 @Getter @Setter
-public class PacketPlayOutTeleportEntity extends PacketOut {
+@AllArgsConstructor
+public class PacketPlayInPlayerPosition extends PacketIn {
 
-    private static final int ID = 0x66;
+    private static final int ID = 0x14;
 
-    private int entityId;
+    static {
+        register(PacketPlayInPlayerPosition.class, ID, PacketState.PLAY_IN,
+                PacketPlayInPlayerPosition::new);
+    }
+
     private EntityPosition position;
     private boolean onGround;
 
-    static {
-        register(PacketPlayOutTeleportEntity.class, ID, PacketState.PLAY_OUT,
-                PacketPlayOutTeleportEntity::new);
-    }
-
-    public PacketPlayOutTeleportEntity(final ServerBuffer buf) {
-        entityId = buf.readVarInt();
-        position = EntityPosition.of(
-                buf.readDouble(),
-                buf.readDouble(),
-                buf.readDouble(),
-                buf.readAngle(),
-                buf.readAngle()
-        );
+    public PacketPlayInPlayerPosition(final ServerBuffer buf) {
+        position = EntityPosition.of(buf.readDouble(), buf.readDouble(), buf.readDouble());
         onGround = buf.readBoolean();
     }
 
@@ -58,21 +50,20 @@ public class PacketPlayOutTeleportEntity extends PacketOut {
 
     @Override
     public PacketState getPacketState() {
-        return PacketState.PLAY_OUT;
+        return PacketState.PLAY_IN;
     }
 
     @Override
     public byte[] serialize() {
-        return new FriendlyByteBuf()
-                .writeVarInt(entityId)
-                .write(position)
-                .writeBoolean(onGround)
+        final FriendlyByteBuf buf = new FriendlyByteBuf();
+        position.writePos(buf);
+        return buf.writeBoolean(onGround)
                 .bytes();
     }
 
     @Override
-    public PacketOut clone() {
-        return new PacketPlayOutTeleportEntity(new FriendlyByteBuf(serialize()));
+    public PacketIn clone() {
+        return new PacketPlayInPlayerPosition(new FriendlyByteBuf(serialize()));
     }
 
 }

--- a/server/src/main/java/org/machinemc/server/network/packets/in/play/PacketPlayInPlayerRotation.java
+++ b/server/src/main/java/org/machinemc/server/network/packets/in/play/PacketPlayInPlayerRotation.java
@@ -12,42 +12,35 @@
  * You should have received a copy of the GNU General Public License along with Machine.
  * If not, see https://www.gnu.org/licenses/.
  */
-package org.machinemc.server.network.packets.out.play;
+package org.machinemc.server.network.packets.in.play;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.machinemc.api.utils.ServerBuffer;
-import org.machinemc.api.world.EntityPosition;
-import org.machinemc.server.network.packets.PacketOut;
+import org.machinemc.server.network.packets.PacketIn;
 import org.machinemc.server.utils.FriendlyByteBuf;
 
-@AllArgsConstructor
+@Getter
+@Setter
 @ToString
-@Getter @Setter
-public class PacketPlayOutTeleportEntity extends PacketOut {
+@AllArgsConstructor
+public class PacketPlayInPlayerRotation extends PacketIn {
 
-    private static final int ID = 0x66;
-
-    private int entityId;
-    private EntityPosition position;
-    private boolean onGround;
+    private static final int ID = 0x16;
 
     static {
-        register(PacketPlayOutTeleportEntity.class, ID, PacketState.PLAY_OUT,
-                PacketPlayOutTeleportEntity::new);
+        register(PacketPlayInPlayerRotation.class, ID, PacketState.PLAY_IN,
+                PacketPlayInPlayerRotation::new);
     }
 
-    public PacketPlayOutTeleportEntity(final ServerBuffer buf) {
-        entityId = buf.readVarInt();
-        position = EntityPosition.of(
-                buf.readDouble(),
-                buf.readDouble(),
-                buf.readDouble(),
-                buf.readAngle(),
-                buf.readAngle()
-        );
+    private float yaw, pitch;
+    private boolean onGround;
+
+    public PacketPlayInPlayerRotation(final ServerBuffer buf) {
+        yaw = buf.readFloat();
+        pitch = buf.readFloat();
         onGround = buf.readBoolean();
     }
 
@@ -58,21 +51,21 @@ public class PacketPlayOutTeleportEntity extends PacketOut {
 
     @Override
     public PacketState getPacketState() {
-        return PacketState.PLAY_OUT;
+        return PacketState.PLAY_IN;
     }
 
     @Override
     public byte[] serialize() {
         return new FriendlyByteBuf()
-                .writeVarInt(entityId)
-                .write(position)
+                .writeFloat(yaw)
+                .writeFloat(pitch)
                 .writeBoolean(onGround)
                 .bytes();
     }
 
     @Override
-    public PacketOut clone() {
-        return new PacketPlayOutTeleportEntity(new FriendlyByteBuf(serialize()));
+    public PacketIn clone() {
+        return new PacketPlayInPlayerRotation(new FriendlyByteBuf(serialize()));
     }
 
 }

--- a/server/src/main/java/org/machinemc/server/network/packets/out/play/PacketPlayOutEntityPositionAndRotation.java
+++ b/server/src/main/java/org/machinemc/server/network/packets/out/play/PacketPlayOutEntityPositionAndRotation.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Machine.
+ *
+ * Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Machine.
+ * If not, see https://www.gnu.org/licenses/.
+ */
+package org.machinemc.server.network.packets.out.play;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.machinemc.api.utils.ServerBuffer;
+import org.machinemc.api.world.EntityPosition;
+import org.machinemc.server.network.packets.PacketOut;
+import org.machinemc.server.utils.FriendlyByteBuf;
+
+@ToString
+@Getter @Setter
+@AllArgsConstructor
+public class PacketPlayOutEntityPositionAndRotation  extends PacketOut {
+
+    private static final int ID = 0x29;
+
+    static {
+        register(PacketPlayOutEntityPositionAndRotation.class, ID, PacketState.PLAY_OUT,
+                PacketPlayOutEntityPositionAndRotation::new);
+    }
+
+    private int entityId;
+    private short deltaX, deltaY, deltaZ;
+    private float yaw, pitch;
+    private boolean onGround;
+
+    public PacketPlayOutEntityPositionAndRotation(final ServerBuffer buf) {
+        entityId = buf.readVarInt();
+        deltaX = buf.readShort();
+        deltaY = buf.readShort();
+        deltaZ = buf.readShort();
+        yaw = buf.readAngle();
+        pitch = buf.readAngle();
+        onGround = buf.readBoolean();
+    }
+
+    public PacketPlayOutEntityPositionAndRotation(final int entityId,
+                                                  final EntityPosition previousPosition,
+                                                  final EntityPosition newPosition,
+                                                  final boolean onGround) {
+        this.entityId = entityId;
+        this.deltaX = (short) ((newPosition.getX() * 32 - previousPosition.getX() * 32) * 128);
+        this.deltaY = (short) ((newPosition.getY() * 32 - previousPosition.getY() * 32) * 128);
+        this.deltaZ = (short) ((newPosition.getZ() * 32 - previousPosition.getZ() * 32) * 128);
+        this.yaw = newPosition.getYaw();
+        this.pitch = newPosition.getPitch();
+        this.onGround = onGround;
+    }
+
+    @Override
+    public int getId() {
+        return ID;
+    }
+
+    @Override
+    public PacketState getPacketState() {
+        return PacketState.PLAY_OUT;
+    }
+
+    @Override
+    public byte[] serialize() {
+        return new FriendlyByteBuf()
+                .writeVarInt(entityId)
+                .writeShort(deltaX)
+                .writeShort(deltaY)
+                .writeShort(deltaZ)
+                .writeAngle(yaw)
+                .writeAngle(pitch)
+                .writeBoolean(onGround)
+                .bytes();
+    }
+
+    @Override
+    public PacketOut clone() {
+        return new PacketPlayOutEntityPositionAndRotation(new FriendlyByteBuf(serialize()));
+    }
+
+}

--- a/server/src/main/java/org/machinemc/server/network/packets/out/play/PacketPlayOutEntityRotation.java
+++ b/server/src/main/java/org/machinemc/server/network/packets/out/play/PacketPlayOutEntityRotation.java
@@ -23,32 +23,34 @@ import org.machinemc.api.world.EntityPosition;
 import org.machinemc.server.network.packets.PacketOut;
 import org.machinemc.server.utils.FriendlyByteBuf;
 
-@AllArgsConstructor
 @ToString
 @Getter @Setter
-public class PacketPlayOutTeleportEntity extends PacketOut {
+@AllArgsConstructor
+public class PacketPlayOutEntityRotation  extends PacketOut {
 
-    private static final int ID = 0x66;
-
-    private int entityId;
-    private EntityPosition position;
-    private boolean onGround;
+    private static final int ID = 0x2A;
 
     static {
-        register(PacketPlayOutTeleportEntity.class, ID, PacketState.PLAY_OUT,
-                PacketPlayOutTeleportEntity::new);
+        register(PacketPlayOutEntityRotation.class, ID, PacketState.PLAY_OUT,
+                PacketPlayOutEntityRotation::new);
     }
 
-    public PacketPlayOutTeleportEntity(final ServerBuffer buf) {
+    private int entityId;
+    private float yaw, pitch;
+    private boolean onGround;
+
+    public PacketPlayOutEntityRotation(final ServerBuffer buf) {
         entityId = buf.readVarInt();
-        position = EntityPosition.of(
-                buf.readDouble(),
-                buf.readDouble(),
-                buf.readDouble(),
-                buf.readAngle(),
-                buf.readAngle()
-        );
+        yaw = buf.readAngle();
+        pitch = buf.readAngle();
         onGround = buf.readBoolean();
+    }
+
+    public PacketPlayOutEntityRotation(final int entityId, final EntityPosition newPosition, final boolean onGround) {
+        this.entityId = entityId;
+        this.yaw = newPosition.getYaw();
+        this.pitch = newPosition.getPitch();
+        this.onGround = onGround;
     }
 
     @Override
@@ -65,14 +67,15 @@ public class PacketPlayOutTeleportEntity extends PacketOut {
     public byte[] serialize() {
         return new FriendlyByteBuf()
                 .writeVarInt(entityId)
-                .write(position)
+                .writeAngle(yaw)
+                .writeAngle(pitch)
                 .writeBoolean(onGround)
                 .bytes();
     }
 
     @Override
     public PacketOut clone() {
-        return new PacketPlayOutTeleportEntity(new FriendlyByteBuf(serialize()));
+        return new PacketPlayOutEntityRotation(new FriendlyByteBuf(serialize()));
     }
 
 }

--- a/server/src/main/java/org/machinemc/server/network/packets/out/play/PacketPlayOutSpawnExperienceOrb.java
+++ b/server/src/main/java/org/machinemc/server/network/packets/out/play/PacketPlayOutSpawnExperienceOrb.java
@@ -19,7 +19,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.machinemc.api.utils.ServerBuffer;
-import org.machinemc.api.utils.math.Vector3;
+import org.machinemc.api.world.EntityPosition;
 import org.machinemc.server.network.packets.PacketOut;
 import org.machinemc.server.utils.FriendlyByteBuf;
 
@@ -31,7 +31,7 @@ public class PacketPlayOutSpawnExperienceOrb extends PacketOut {
     private static final int ID = 0x01;
 
     private int entityId;
-    private Vector3 position;
+    private EntityPosition position;
     private short count;
 
     static {
@@ -41,7 +41,7 @@ public class PacketPlayOutSpawnExperienceOrb extends PacketOut {
 
     public PacketPlayOutSpawnExperienceOrb(final ServerBuffer buf) {
         entityId = buf.readVarInt();
-        position = Vector3.of(buf.readDouble(), buf.readDouble(), buf.readDouble());
+        position = EntityPosition.of(buf.readDouble(), buf.readDouble(), buf.readDouble());
         count = buf.readByte();
     }
 

--- a/server/src/main/java/org/machinemc/server/network/packets/out/play/PacketPlayOutSpawnPlayer.java
+++ b/server/src/main/java/org/machinemc/server/network/packets/out/play/PacketPlayOutSpawnPlayer.java
@@ -19,8 +19,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.machinemc.api.utils.ServerBuffer;
-import org.machinemc.api.utils.math.Vector2;
-import org.machinemc.api.utils.math.Vector3;
+import org.machinemc.api.world.EntityPosition;
 import org.machinemc.server.network.packets.PacketOut;
 import org.machinemc.server.utils.FriendlyByteBuf;
 
@@ -35,8 +34,7 @@ public class PacketPlayOutSpawnPlayer extends PacketOut {
 
     private int entityId;
     private UUID uuid;
-    private Vector3 position;
-    private Vector2 rotation;
+    private EntityPosition position;
 
 
     static {
@@ -47,8 +45,7 @@ public class PacketPlayOutSpawnPlayer extends PacketOut {
     public PacketPlayOutSpawnPlayer(final ServerBuffer buf) {
         entityId = buf.readVarInt();
         uuid = buf.readUUID();
-        position = Vector3.of(buf.readDouble(), buf.readDouble(), buf.readDouble());
-        rotation = Vector2.of(buf.readAngle(), buf.readAngle());
+        position = EntityPosition.read(buf);
     }
 
     @Override
@@ -66,8 +63,7 @@ public class PacketPlayOutSpawnPlayer extends PacketOut {
         return new FriendlyByteBuf()
                 .writeVarInt(entityId)
                 .writeUUID(uuid)
-                .writeDouble(position.getX()).writeDouble(position.getY()).writeDouble(position.getZ())
-                .writeAngle((float) rotation.getX()).writeAngle((float) rotation.getY())
+                .write(position)
                 .bytes();
     }
 

--- a/server/src/main/java/org/machinemc/server/network/packets/out/play/PacketPlayOutSynchronizePlayerPosition.java
+++ b/server/src/main/java/org/machinemc/server/network/packets/out/play/PacketPlayOutSynchronizePlayerPosition.java
@@ -1,0 +1,142 @@
+/*
+ * This file is part of Machine.
+ *
+ * Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Machine.
+ * If not, see https://www.gnu.org/licenses/.
+ */
+package org.machinemc.server.network.packets.out.play;
+
+import lombok.*;
+import org.jetbrains.annotations.Unmodifiable;
+import org.machinemc.api.utils.ServerBuffer;
+import org.machinemc.api.world.Location;
+import org.machinemc.server.network.packets.PacketOut;
+import org.machinemc.server.utils.FriendlyByteBuf;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+@ToString
+@Getter @Setter
+@AllArgsConstructor
+public class PacketPlayOutSynchronizePlayerPosition  extends PacketOut {
+
+    private static final int ID = 0x39;
+
+    static {
+        register(PacketPlayOutSynchronizePlayerPosition.class, ID, PacketState.PLAY_OUT,
+                PacketPlayOutSynchronizePlayerPosition::new);
+    }
+
+    private double x, y, z;
+    private float yaw, pitch;
+    private Set<TeleportFlags> flags;
+    private int teleportId;
+    private boolean dismountVehicle;
+
+    public PacketPlayOutSynchronizePlayerPosition(final ServerBuffer buf) {
+        x = buf.readDouble();
+        y = buf.readDouble();
+        z = buf.readDouble();
+        yaw = buf.readFloat();
+        pitch = buf.readFloat();
+        flags = TeleportFlags.unpack(buf.readByte());
+        teleportId = buf.readVarInt();
+        dismountVehicle = buf.readBoolean();
+    }
+
+    public PacketPlayOutSynchronizePlayerPosition(final Location location,
+                                                  final Set<TeleportFlags> flags,
+                                                  final int teleportId,
+                                                  final boolean dismountVehicle) {
+        this(location.getX(), location.getY(), location.getZ(), location.getYaw(),
+                location.getPitch(), flags, teleportId, dismountVehicle);
+    }
+
+    @Override
+    public int getId() {
+        return ID;
+    }
+
+    @Override
+    public PacketState getPacketState() {
+        return PacketState.PLAY_OUT;
+    }
+
+    @Override
+    public byte[] serialize() {
+        return new FriendlyByteBuf()
+                .writeDouble(x)
+                .writeDouble(y)
+                .writeDouble(z)
+                .writeFloat(yaw)
+                .writeFloat(pitch)
+                .writeByte((byte) TeleportFlags.pack(flags))
+                .writeVarInt(teleportId)
+                .writeBoolean(dismountVehicle)
+                .bytes();
+    }
+
+    @Override
+    public PacketOut clone() {
+        return new PacketPlayOutSynchronizePlayerPosition(new FriendlyByteBuf(serialize()));
+    }
+
+    @RequiredArgsConstructor
+    public enum TeleportFlags {
+        X(0),
+        Y(1),
+        Z(2),
+        PITCH(3),
+        YAW(4);
+
+        private final int bit;
+
+        private int getMask() {
+            return 1 << bit;
+        }
+
+        private boolean isSet(final int flag) {
+            return (flag & getMask()) == getMask();
+        }
+
+        /**
+         * Creates set of teleport flags from a bit mask.
+         * @param flag bit mask
+         * @return teleport flags
+         */
+        public static @Unmodifiable Set<TeleportFlags> unpack(final int flag) {
+            final Set<TeleportFlags> set = EnumSet.noneOf(TeleportFlags.class);
+            for (final TeleportFlags value : values()) {
+                if (value.isSet(flag))
+                    set.add(value);
+            }
+            return Collections.unmodifiableSet(set);
+        }
+
+        /**
+         * Creates mask from given flags.
+         * @param flags flags
+         * @return created bit mask
+         */
+        public static int pack(final Set<TeleportFlags> flags) {
+            int flag = 0;
+
+            for (final TeleportFlags teleportFlag : flags)
+                flag |= teleportFlag.getMask();
+
+            return flag;
+        }
+
+    }
+
+}

--- a/server/src/main/java/org/machinemc/server/translation/TranslatorDispatcher.java
+++ b/server/src/main/java/org/machinemc/server/translation/TranslatorDispatcher.java
@@ -57,8 +57,8 @@ public class TranslatorDispatcher {
         final List<String> classes = ClassUtils.getClasses(TranslatorDispatcher.class.getPackageName());
         for (final String className : classes) {
             final Class<?> translatorClass = Class.forName(className);
-            if (translatorClass.getSuperclass() == null
-                    || !translatorClass.getSuperclass().equals(PacketTranslator.class))
+            if (!PacketTranslator.class.isAssignableFrom(translatorClass)
+                    || translatorClass.equals(PacketTranslator.class))
                 continue;
             PacketTranslator<?> translator = null;
             try {

--- a/server/src/main/java/org/machinemc/server/translation/translators/in/handshaking/TranslatorHandshakingInHandshake.java
+++ b/server/src/main/java/org/machinemc/server/translation/translators/in/handshaking/TranslatorHandshakingInHandshake.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License along with Machine.
  * If not, see https://www.gnu.org/licenses/.
  */
-package org.machinemc.server.translation.translators.in;
+package org.machinemc.server.translation.translators.in.handshaking;
 
 import org.machinemc.api.network.PlayerConnection;
 import org.machinemc.server.translation.PacketTranslator;

--- a/server/src/main/java/org/machinemc/server/translation/translators/in/login/TranslatorLoginInEncryptionResponse.java
+++ b/server/src/main/java/org/machinemc/server/translation/translators/in/login/TranslatorLoginInEncryptionResponse.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License along with Machine.
  * If not, see https://www.gnu.org/licenses/.
  */
-package org.machinemc.server.translation.translators.in;
+package org.machinemc.server.translation.translators.in.login;
 
 import org.machinemc.api.auth.OnlineServer;
 import org.machinemc.api.entities.player.PlayerProfile;

--- a/server/src/main/java/org/machinemc/server/translation/translators/in/login/TranslatorLoginInStart.java
+++ b/server/src/main/java/org/machinemc/server/translation/translators/in/login/TranslatorLoginInStart.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License along with Machine.
  * If not, see https://www.gnu.org/licenses/.
  */
-package org.machinemc.server.translation.translators.in;
+package org.machinemc.server.translation.translators.in.login;
 
 import org.machinemc.api.auth.OnlineServer;
 import org.machinemc.api.network.PlayerConnection;

--- a/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInChatMessage.java
+++ b/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInChatMessage.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License along with Machine.
  * If not, see https://www.gnu.org/licenses/.
  */
-package org.machinemc.server.translation.translators.in;
+package org.machinemc.server.translation.translators.in.play;
 
 import org.machinemc.api.chat.MessageType;
 import org.machinemc.api.chat.Messenger;

--- a/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInClientInformation.java
+++ b/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInClientInformation.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License along with Machine.
  * If not, see https://www.gnu.org/licenses/.
  */
-package org.machinemc.server.translation.translators.in;
+package org.machinemc.server.translation.translators.in.play;
 
 import org.machinemc.server.entities.ServerPlayer;
 import org.machinemc.server.network.ClientConnection;

--- a/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInConfirmTeleportation.java
+++ b/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInConfirmTeleportation.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Machine.
+ *
+ * Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Machine.
+ * If not, see https://www.gnu.org/licenses/.
+ */
+package org.machinemc.server.translation.translators.in.play;
+
+import org.machinemc.server.entities.ServerPlayer;
+import org.machinemc.server.network.ClientConnection;
+import org.machinemc.server.network.packets.in.play.PacketPlayInConfirmTeleportation;
+import org.machinemc.server.translation.PacketTranslator;
+
+public class TranslatorPlayInConfirmTeleportation extends PacketTranslator<PacketPlayInConfirmTeleportation> {
+
+    @Override
+    public boolean translate(final ClientConnection connection, final PacketPlayInConfirmTeleportation packet) {
+        final ServerPlayer player = connection.getOwner();
+        if (player == null)
+            return false;
+        if (!player.isTeleporting() || player.getTeleportId() != packet.getTeleportId()) {
+            player.setTeleporting(false);
+            // connection.disconnect(TranslationComponent.of("multiplayer.disconnect.invalid_player_movement"));
+            System.out.println(player.isTeleporting() + " "
+                    + player.getTeleportId() + "="
+                    + packet.getTeleportId());
+            return false;
+        }
+        player.setTeleporting(false);
+        player.setLocation(player.getTeleportLocation());
+        player.setTeleportLocation(null);
+        return true;
+    }
+
+    @Override
+    public void translateAfter(final ClientConnection connection, final PacketPlayInConfirmTeleportation packet) {
+
+    }
+
+    @Override
+    public Class<PacketPlayInConfirmTeleportation> packetClass() {
+        return PacketPlayInConfirmTeleportation.class;
+    }
+
+}

--- a/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInConfirmTeleportation.java
+++ b/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInConfirmTeleportation.java
@@ -14,7 +14,6 @@
  */
 package org.machinemc.server.translation.translators.in.play;
 
-import org.machinemc.scriptive.components.TranslationComponent;
 import org.machinemc.server.entities.ServerPlayer;
 import org.machinemc.server.network.ClientConnection;
 import org.machinemc.server.network.packets.in.play.PacketPlayInConfirmTeleportation;
@@ -27,15 +26,7 @@ public class TranslatorPlayInConfirmTeleportation extends PacketTranslator<Packe
         final ServerPlayer player = connection.getOwner();
         if (player == null)
             return false;
-        if (!player.isTeleporting() || player.getTeleportId() != packet.getTeleportId()) {
-            player.setTeleporting(false);
-            connection.disconnect(TranslationComponent.of("multiplayer.disconnect.invalid_player_movement"));
-            return false;
-        }
-        player.setTeleporting(false);
-        player.setLocation(player.getTeleportLocation());
-        player.setTeleportLocation(null);
-        return true;
+        return player.handleTeleportConfirm(packet.getTeleportId());
     }
 
     @Override

--- a/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInConfirmTeleportation.java
+++ b/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInConfirmTeleportation.java
@@ -14,6 +14,7 @@
  */
 package org.machinemc.server.translation.translators.in.play;
 
+import org.machinemc.scriptive.components.TranslationComponent;
 import org.machinemc.server.entities.ServerPlayer;
 import org.machinemc.server.network.ClientConnection;
 import org.machinemc.server.network.packets.in.play.PacketPlayInConfirmTeleportation;
@@ -28,10 +29,7 @@ public class TranslatorPlayInConfirmTeleportation extends PacketTranslator<Packe
             return false;
         if (!player.isTeleporting() || player.getTeleportId() != packet.getTeleportId()) {
             player.setTeleporting(false);
-            // connection.disconnect(TranslationComponent.of("multiplayer.disconnect.invalid_player_movement"));
-            System.out.println(player.isTeleporting() + " "
-                    + player.getTeleportId() + "="
-                    + packet.getTeleportId());
+            connection.disconnect(TranslationComponent.of("multiplayer.disconnect.invalid_player_movement"));
             return false;
         }
         player.setTeleporting(false);

--- a/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInKeepAlive.java
+++ b/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInKeepAlive.java
@@ -12,28 +12,29 @@
  * You should have received a copy of the GNU General Public License along with Machine.
  * If not, see https://www.gnu.org/licenses/.
  */
-package org.machinemc.server.translation.translators.in;
+package org.machinemc.server.translation.translators.in.play;
 
-import org.machinemc.server.translation.PacketTranslator;
 import org.machinemc.server.network.ClientConnection;
-import org.machinemc.server.network.packets.in.status.PacketStatusInRequest;
-import org.machinemc.server.network.packets.out.status.PacketStatusOutResponse;
+import org.machinemc.server.translation.PacketTranslator;
+import org.machinemc.server.network.packets.in.play.PacketPlayInKeepAlive;
 
-public class TranslatorStatusInRequest extends PacketTranslator<PacketStatusInRequest> {
+public class TranslatorPlayInKeepAlive extends PacketTranslator<PacketPlayInKeepAlive> {
 
     @Override
-    public boolean translate(final ClientConnection connection, final PacketStatusInRequest packet) {
+    public boolean translate(final ClientConnection connection, final PacketPlayInKeepAlive packet) {
+        if (packet.getKeepAliveId() != connection.getKeepAliveKey()) return false;
+        connection.keepAlive();
         return true;
     }
 
     @Override
-    public void translateAfter(final ClientConnection connection, final PacketStatusInRequest packet) {
-        connection.send(new PacketStatusOutResponse(connection.getServer().statusJson()));
+    public void translateAfter(final ClientConnection connection, final PacketPlayInKeepAlive packet) {
+
     }
 
     @Override
-    public Class<PacketStatusInRequest> packetClass() {
-        return PacketStatusInRequest.class;
+    public Class<PacketPlayInKeepAlive> packetClass() {
+        return PacketPlayInKeepAlive.class;
     }
 
 }

--- a/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInPlayerOnGround.java
+++ b/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInPlayerOnGround.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Machine.
+ *
+ * Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Machine.
+ * If not, see https://www.gnu.org/licenses/.
+ */
+package org.machinemc.server.translation.translators.in.play;
+
+import org.machinemc.server.entities.ServerPlayer;
+import org.machinemc.server.network.ClientConnection;
+import org.machinemc.server.network.packets.in.play.PacketPlayInPlayerOnGround;
+import org.machinemc.server.translation.PacketTranslator;
+
+public class TranslatorPlayInPlayerOnGround extends PacketTranslator<PacketPlayInPlayerOnGround> {
+
+    private ServerPlayer player;
+
+    @Override
+    public boolean translate(final ClientConnection connection, final PacketPlayInPlayerOnGround packet) {
+        player = connection.getOwner();
+        return player != null;
+    }
+
+    @Override
+    public void translateAfter(final ClientConnection connection, final PacketPlayInPlayerOnGround packet) {
+        player.handleOnGround(packet.isOnGround());
+    }
+
+    @Override
+    public Class<PacketPlayInPlayerOnGround> packetClass() {
+        return PacketPlayInPlayerOnGround.class;
+    }
+
+}

--- a/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInPlayerPosition.java
+++ b/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInPlayerPosition.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Machine.
+ *
+ * Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Machine.
+ * If not, see https://www.gnu.org/licenses/.
+ */
+package org.machinemc.server.translation.translators.in.play;
+
+import org.machinemc.api.world.EntityPosition;
+import org.machinemc.api.world.Location;
+import org.machinemc.scriptive.components.TranslationComponent;
+import org.machinemc.server.entities.ServerPlayer;
+import org.machinemc.server.network.ClientConnection;
+import org.machinemc.server.network.packets.in.play.PacketPlayInPlayerPosition;
+import org.machinemc.server.translation.PacketTranslator;
+
+public class TranslatorPlayInPlayerPosition  extends PacketTranslator<PacketPlayInPlayerPosition> {
+
+    private ServerPlayer player;
+    private EntityPosition position;
+
+    @Override
+    public boolean translate(final ClientConnection connection, final PacketPlayInPlayerPosition packet) {
+        player = connection.getOwner();
+        if (player == null)
+            return false;
+        position = packet.getPosition()
+                .withYaw(player.getLocation().getYaw())
+                .withPitch(player.getLocation().getPitch());
+        if (Location.isInvalid(position)) {
+            connection.disconnect(TranslationComponent.of("multiplayer.disconnect.invalid_player_movement"));
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void translateAfter(final ClientConnection connection, final PacketPlayInPlayerPosition packet) {
+        player.handleMovement(position, packet.isOnGround());
+    }
+
+    @Override
+    public Class<PacketPlayInPlayerPosition> packetClass() {
+        return PacketPlayInPlayerPosition.class;
+    }
+
+}

--- a/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInPlayerPositionAndRotation.java
+++ b/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInPlayerPositionAndRotation.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Machine.
+ *
+ * Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Machine.
+ * If not, see https://www.gnu.org/licenses/.
+ */
+package org.machinemc.server.translation.translators.in.play;
+
+import org.machinemc.api.world.EntityPosition;
+import org.machinemc.api.world.Location;
+import org.machinemc.scriptive.components.TranslationComponent;
+import org.machinemc.server.entities.ServerPlayer;
+import org.machinemc.server.network.ClientConnection;
+import org.machinemc.server.network.packets.in.play.PacketPlayInPlayerPositionAndRotation;
+import org.machinemc.server.translation.PacketTranslator;
+
+public class TranslatorPlayInPlayerPositionAndRotation extends PacketTranslator<PacketPlayInPlayerPositionAndRotation> {
+
+    private ServerPlayer player;
+    private EntityPosition position;
+
+    @Override
+    public boolean translate(final ClientConnection connection, final PacketPlayInPlayerPositionAndRotation packet) {
+        player = connection.getOwner();
+        if (player == null)
+            return false;
+        position = packet.getPosition();
+        if (Location.isInvalid(position)) {
+            connection.disconnect(TranslationComponent.of("multiplayer.disconnect.invalid_player_movement"));
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void translateAfter(final ClientConnection connection, final PacketPlayInPlayerPositionAndRotation packet) {
+        player.handleMovement(position, packet.isOnGround());
+    }
+
+    @Override
+    public Class<PacketPlayInPlayerPositionAndRotation> packetClass() {
+        return PacketPlayInPlayerPositionAndRotation.class;
+    }
+
+}

--- a/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInPlayerRotation.java
+++ b/server/src/main/java/org/machinemc/server/translation/translators/in/play/TranslatorPlayInPlayerRotation.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Machine.
+ *
+ * Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Machine.
+ * If not, see https://www.gnu.org/licenses/.
+ */
+package org.machinemc.server.translation.translators.in.play;
+
+import org.machinemc.api.world.EntityPosition;
+import org.machinemc.scriptive.components.TranslationComponent;
+import org.machinemc.server.entities.ServerPlayer;
+import org.machinemc.server.network.ClientConnection;
+import org.machinemc.server.network.packets.in.play.PacketPlayInPlayerRotation;
+import org.machinemc.server.translation.PacketTranslator;
+
+public class TranslatorPlayInPlayerRotation extends PacketTranslator<PacketPlayInPlayerRotation> {
+
+    private ServerPlayer player;
+    private EntityPosition position;
+
+    @Override
+    public boolean translate(final ClientConnection connection, final PacketPlayInPlayerRotation packet) {
+        player = connection.getOwner();
+        if (player == null)
+            return false;
+        position = player.getLocation();
+        position.setYaw(packet.getYaw());
+        position.setPitch(packet.getPitch());
+        if (EntityPosition.isInvalid(position)) {
+            connection.disconnect(TranslationComponent.of("multiplayer.disconnect.invalid_player_movement"));
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void translateAfter(final ClientConnection connection, final PacketPlayInPlayerRotation packet) {
+        player.handleMovement(position, packet.isOnGround());
+    }
+
+    @Override
+    public Class<PacketPlayInPlayerRotation> packetClass() {
+        return PacketPlayInPlayerRotation.class;
+    }
+
+}

--- a/server/src/main/java/org/machinemc/server/translation/translators/in/status/TranslatorStatusInPing.java
+++ b/server/src/main/java/org/machinemc/server/translation/translators/in/status/TranslatorStatusInPing.java
@@ -12,29 +12,29 @@
  * You should have received a copy of the GNU General Public License along with Machine.
  * If not, see https://www.gnu.org/licenses/.
  */
-package org.machinemc.server.translation.translators.in;
+package org.machinemc.server.translation.translators.in.status;
 
 import org.machinemc.server.network.ClientConnection;
 import org.machinemc.server.translation.PacketTranslator;
-import org.machinemc.server.network.packets.in.play.PacketPlayInKeepAlive;
+import org.machinemc.server.network.packets.in.status.PacketStatusInPing;
+import org.machinemc.server.network.packets.out.status.PacketStatusOutPong;
 
-public class TranslatorPlayInKeepAlive extends PacketTranslator<PacketPlayInKeepAlive> {
+public class TranslatorStatusInPing extends PacketTranslator<PacketStatusInPing> {
 
     @Override
-    public boolean translate(final ClientConnection connection, final PacketPlayInKeepAlive packet) {
-        if (packet.getKeepAliveId() != connection.getKeepAliveKey()) return false;
-        connection.keepAlive();
+    public boolean translate(final ClientConnection connection, final PacketStatusInPing packet) {
         return true;
     }
 
     @Override
-    public void translateAfter(final ClientConnection connection, final PacketPlayInKeepAlive packet) {
-
+    public void translateAfter(final ClientConnection connection, final PacketStatusInPing packet) {
+        connection.send(new PacketStatusOutPong(packet.getPayload()));
+        connection.disconnect();
     }
 
     @Override
-    public Class<PacketPlayInKeepAlive> packetClass() {
-        return PacketPlayInKeepAlive.class;
+    public Class<PacketStatusInPing> packetClass() {
+        return PacketStatusInPing.class;
     }
 
 }

--- a/server/src/main/java/org/machinemc/server/translation/translators/in/status/TranslatorStatusInRequest.java
+++ b/server/src/main/java/org/machinemc/server/translation/translators/in/status/TranslatorStatusInRequest.java
@@ -12,29 +12,28 @@
  * You should have received a copy of the GNU General Public License along with Machine.
  * If not, see https://www.gnu.org/licenses/.
  */
-package org.machinemc.server.translation.translators.in;
+package org.machinemc.server.translation.translators.in.status;
 
-import org.machinemc.server.network.ClientConnection;
 import org.machinemc.server.translation.PacketTranslator;
-import org.machinemc.server.network.packets.in.status.PacketStatusInPing;
-import org.machinemc.server.network.packets.out.status.PacketStatusOutPong;
+import org.machinemc.server.network.ClientConnection;
+import org.machinemc.server.network.packets.in.status.PacketStatusInRequest;
+import org.machinemc.server.network.packets.out.status.PacketStatusOutResponse;
 
-public class TranslatorStatusInPing extends PacketTranslator<PacketStatusInPing> {
+public class TranslatorStatusInRequest extends PacketTranslator<PacketStatusInRequest> {
 
     @Override
-    public boolean translate(final ClientConnection connection, final PacketStatusInPing packet) {
+    public boolean translate(final ClientConnection connection, final PacketStatusInRequest packet) {
         return true;
     }
 
     @Override
-    public void translateAfter(final ClientConnection connection, final PacketStatusInPing packet) {
-        connection.send(new PacketStatusOutPong(packet.getPayload()));
-        connection.disconnect();
+    public void translateAfter(final ClientConnection connection, final PacketStatusInRequest packet) {
+        connection.send(new PacketStatusOutResponse(connection.getServer().statusJson()));
     }
 
     @Override
-    public Class<PacketStatusInPing> packetClass() {
-        return PacketStatusInPing.class;
+    public Class<PacketStatusInRequest> packetClass() {
+        return PacketStatusInRequest.class;
     }
 
 }

--- a/server/src/main/java/org/machinemc/server/utils/FriendlyByteBuf.java
+++ b/server/src/main/java/org/machinemc/server/utils/FriendlyByteBuf.java
@@ -77,8 +77,7 @@ public class FriendlyByteBuf implements ServerBuffer {
         final int reader = buf.readerIndex();
         buf.readerIndex(0);
         final byte[] bytes = new byte[length];
-        for (int i = 0; i < length; i++)
-            bytes[i] = readByte();
+        buf.readBytes(bytes);
         buf.readerIndex(reader);
         return bytes;
     }
@@ -88,8 +87,7 @@ public class FriendlyByteBuf implements ServerBuffer {
         final int length = buf.writerIndex();
         final int reader = buf.readerIndex();
         final byte[] bytes = new byte[length - reader];
-        for (int i = 0; i < length - reader; i++)
-            bytes[i] = readByte();
+        buf.readBytes(bytes);
         return bytes;
     }
 
@@ -138,8 +136,7 @@ public class FriendlyByteBuf implements ServerBuffer {
     @Override
     public byte[] readBytes(final int length) {
         final byte[] result = new byte[length];
-        for (int i = 0; i < length; i++)
-            result[i] = readByte();
+        buf.readBytes(result);
         return result;
     }
 
@@ -153,8 +150,7 @@ public class FriendlyByteBuf implements ServerBuffer {
     public byte[] readByteArray() {
         final int length = readVarInt();
         final byte[] bytes = new byte[length];
-        for (int i = 0; i < length; i++)
-            bytes[i] = readByte();
+        buf.readBytes(bytes);
         return bytes;
     }
 

--- a/server/src/main/java/org/machinemc/server/world/ServerWorld.java
+++ b/server/src/main/java/org/machinemc/server/world/ServerWorld.java
@@ -189,7 +189,10 @@ public class ServerWorld extends AbstractWorld {
         getServer().getConsole().info("Saved world '" + getName() + "'");
     }
 
-    @Override
+    /**
+     * Loads the player to the world.
+     * @param player player to load
+     */
     public void loadPlayer(final Player player) {
         // TODO this should take player's view distance
         final Scheduler scheduler = getServer().getScheduler();
@@ -247,21 +250,28 @@ public class ServerWorld extends AbstractWorld {
         return new int[] {x, y};
     }
 
-    @Override
+    /**
+     * Unloads the player from the world.
+     * @param player player to unload
+     */
     public void unloadPlayer(final Player player) {
         // TODO implement player unloading
     }
 
     @Override
-    public boolean spawn(final Entity entity, final Location location) {
-        entityList.add(entity); // TODO implement entity spawning
-        return true;
+    public boolean spawn(final Entity entity) {
+        if (entity.getWorld() != this) return false;
+        if (entity instanceof Player player)
+            loadPlayer(player);
+        return entityList.add(entity); // TODO implement entity spawning
     }
 
     @Override
     public boolean remove(final Entity entity) {
-        entityList.remove(entity); // TODO implement entity removing
-        return true;
+        if (!entityList.contains(entity)) return false;
+        if (entity instanceof Player player)
+            unloadPlayer(player);
+        return entityList.remove(entity); // TODO implement entity removing
     }
 
     @Override


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Implementation of the player movement.

**What is the current behavior?** (You can also link to an open issue here)
There is no implementation for player spawning or player movement.

**What is the new behavior?** (If this is a feature change)
Players can now move around the world and see others.

**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
Load and unload methods for the worlds were removed from the API, the spawn method now takes only the entity as
an argument except for both entity and its location.


* [x] I follow Machine contributing guidelines